### PR TITLE
Update Btn.svelte to have tabindex

### DIFF
--- a/.changeset/chatty-boats-deny.md
+++ b/.changeset/chatty-boats-deny.md
@@ -1,0 +1,5 @@
+---
+'@sveltepress/theme-default': patch
+---
+
+fix: add tabIndex to pwa button to avoid build time warning

--- a/packages/theme-default/src/components/pwa/Btn.svelte
+++ b/packages/theme-default/src/components/pwa/Btn.svelte
@@ -17,6 +17,7 @@
   class:flat
   on:click={handleClick}
   on:keyup={handleClick}
+  tabindex="0"
 >
   <slot />
 </div>


### PR DESCRIPTION
I got the following error while building:

```
vite v4.3.9 building for production...
transforming (539) node_modules/@sveltepress/theme-default/dist/components/icons/PointLeft.s2:58:24 PM [vite-plugin-svelte] /node_modules/@sveltepress/theme-default/dist/components/pwa/Btn.svelte:9:0 A11y: Elements with the 'button' interactive role must have a tabindex value.
 7: </script>
 8: 
 9: <div
    ^
10:   role="button"
11:   class="btn"
```

Best regards