### PR TITLE
Default base path prefixed for URIs

### DIFF
--- a/.changeset/honest-students-act.md
+++ b/.changeset/honest-students-act.md
@@ -1,0 +1,8 @@
+---
+"@sveltepress/theme-default": minor
+"@sveltepress/create": minor
+"@sveltepress/twoslash": minor
+"@sveltepress/vite": minor
+---
+
+feat: auto add base path for links and logo image sources (#159)

--- a/packages/theme-default/src/components/ActionButton.svelte
+++ b/packages/theme-default/src/components/ActionButton.svelte
@@ -1,6 +1,6 @@
 <script>
-  import { base } from '$app/paths'
   import External from './icons/External.svelte'
+  import { getPathFromBase } from './utils'
 
   /**
    * @typedef {object} Props
@@ -12,13 +12,11 @@
 
   /** @type {Props} */
   let { label, type = '', to, external = false } = $props()
-
-  const toWithBase = base + to
 </script>
 
 <a
   role="button"
-  href={external ? to : toWithBase}
+  href={external ? to : getPathFromBase(to)}
   class={`svp-action ${type ? `svp-action--${type}` : ''}`}
   target={external ? '_blank' : ''}
 >

--- a/packages/theme-default/src/components/Link.svelte
+++ b/packages/theme-default/src/components/Link.svelte
@@ -1,6 +1,6 @@
 <script>
-  import { base } from '$app/paths'
   import External from './icons/External.svelte'
+  import { getPathFromBase } from './utils'
 
   /**
    * @typedef {object} Props
@@ -22,14 +22,14 @@
     inline = true,
     active = false,
     highlight = true,
-    withBase = false,
+    withBase = true,
     pre,
     labelRenderer,
     children,
   } = $props()
 
   const isExternal = $derived(/^https?|mailto:/.test(to))
-  const toWithBase = $derived(isExternal ? to : `${base}${to}`)
+  const toWithBase = $derived(isExternal ? to : getPathFromBase(to))
 </script>
 
 <a

--- a/packages/theme-default/src/components/Logo.svelte
+++ b/packages/theme-default/src/components/Logo.svelte
@@ -1,11 +1,11 @@
 <script>
-  import { base } from '$app/paths'
   import siteConfig from 'virtual:sveltepress/site'
   import themeOptions from 'virtual:sveltepress/theme-default'
   import NavItem from './NavItem.svelte'
+  import { getPathFromBase } from './utils'
 </script>
 
-<NavItem to={base === '' ? '/' : base} title={siteConfig.title}>
+<NavItem to={getPathFromBase('/')} title={siteConfig.title}>
   {#if themeOptions.logo}
     <img
       class="logo"

--- a/packages/theme-default/src/components/Logo.svelte
+++ b/packages/theme-default/src/components/Logo.svelte
@@ -2,7 +2,7 @@
   import siteConfig from 'virtual:sveltepress/site'
   import themeOptions from 'virtual:sveltepress/theme-default'
   import NavItem from './NavItem.svelte'
-  import { getPathFromBase } from './utils'
+  import { getPathFromBase, parseImageSrc } from './utils'
 </script>
 
 <NavItem to={getPathFromBase('/')} title={siteConfig.title}>
@@ -10,7 +10,7 @@
     <img
       class="logo"
       height="32"
-      src={themeOptions.logo}
+      src={parseImageSrc(themeOptions.logo)}
       alt={siteConfig.title}
     />
     <span class="title">

--- a/packages/theme-default/src/components/NavItem.svelte
+++ b/packages/theme-default/src/components/NavItem.svelte
@@ -3,6 +3,7 @@
   import NavArrowDown from './icons/NavArrowDown.svelte'
   // eslint-disable-next-line import/no-self-import
   import Self from './NavItem.svelte'
+  import { getPathFromBase } from './utils'
 
   /**
    * @typedef {object} Props
@@ -62,7 +63,7 @@
 {:else}
   <svelte:element
     this={external ? 'div' : 'a'}
-    href={to}
+    href={external ? to : getPathFromBase(to)}
     class:nav-item--icon={icon}
     class="nav-item"
     {...external ? { target: '_blank' } : {}}

--- a/packages/theme-default/src/components/PageSwitcher.svelte
+++ b/packages/theme-default/src/components/PageSwitcher.svelte
@@ -1,10 +1,10 @@
 <script>
-  import { base } from '$app/paths'
   import { page } from '$app/stores'
   import themOptions from 'virtual:sveltepress/theme-default'
   import Next from './icons/Next.svelte'
   import Prev from './icons/Prev.svelte'
   import { pages } from './layout'
+  import { getPathFromBase } from './utils'
 
   const routeId = $page.route.id
 
@@ -23,7 +23,7 @@
   <div class:switcher={hasPrevPage}>
     {#if hasPrevPage}
       {@const prevPage = $pages[activeIdx - 1]}
-      <a href={base + prevPage.to} class="trigger">
+      <a href={getPathFromBase(prevPage.to)} class="trigger">
         <div class="hint">
           {themOptions.i18n?.previousPage || DEFAULT_PREVIOUS_TEXT}
         </div>
@@ -41,7 +41,7 @@
   <div class="right" class:switcher={hasNextPage}>
     {#if hasNextPage}
       {@const nextPage = $pages[activeIdx + 1]}
-      <a href={base + nextPage.to} class="trigger">
+      <a href={getPathFromBase(prevPage.to)} class="trigger">
         <div class="hint">
           {themOptions.i18n?.nextPage || DEFAULT_NEXT_TEXT}
         </div>

--- a/packages/theme-default/src/components/home/HeroImage.svelte
+++ b/packages/theme-default/src/components/home/HeroImage.svelte
@@ -1,11 +1,12 @@
 <script>
   import siteConfig from 'virtual:sveltepress/site'
+  import { parseImageSrc } from '../utils'
 
   const { heroImage } = $props()
 </script>
 
 <div class="hero-image">
-  <img src={heroImage} alt={siteConfig.title} width="192" />
+  <img src={parseImageSrc(heroImage)} alt={siteConfig.title} width="192" />
 </div>
 
 <style>

--- a/packages/theme-default/src/components/utils.ts
+++ b/packages/theme-default/src/components/utils.ts
@@ -3,21 +3,15 @@ import { base } from '$app/paths'
 function getPathFromBase(path: string) {
   if (path === '/')
     return ''
-  if (!base)
+  if (!base || !path.startsWith('/') || path.startsWith(base))
     return path
   return `${base}${path}`
 }
 
 function parseImageSrc(src: string) {
-  if (src.startsWith('/')) {
-    if (src.startsWith('//'))
-      return src
-    if (src.startsWith(base)) {
-      return src
-    }
-    return getPathFromBase(src)
-  }
-  return src
+  if (src.startsWith('//'))
+    return src
+  return getPathFromBase(src)
 }
 
 export { getPathFromBase, parseImageSrc }

--- a/packages/theme-default/src/components/utils.ts
+++ b/packages/theme-default/src/components/utils.ts
@@ -9,11 +9,15 @@ function getPathFromBase(path: string) {
 }
 
 function parseImageSrc(src: string) {
-  if (src.startsWith('data:'))
-    return src
-  if (src.startsWith('http://') || src.startsWith('https://'))
-    return src
-  return getPathFromBase(src)
+  if (src.startsWith('/')) {
+    if (src.startsWith('//'))
+      return src
+    if (src.startsWith(base)) {
+      return src
+    }
+    return getPathFromBase(src)
+  }
+  return src
 }
 
 export { getPathFromBase, parseImageSrc }

--- a/packages/theme-default/src/components/utils.ts
+++ b/packages/theme-default/src/components/utils.ts
@@ -8,4 +8,12 @@ function getPathFromBase(path: string) {
   return `${base}${path}`
 }
 
-export { getPathFromBase }
+function parseImageSrc(src: string) {
+  if (src.startsWith('data:'))
+    return src
+  if (src.startsWith('http://') || src.startsWith('https://'))
+    return src
+  return getPathFromBase(src)
+}
+
+export { getPathFromBase, parseImageSrc }

--- a/packages/theme-default/src/components/utils.ts
+++ b/packages/theme-default/src/components/utils.ts
@@ -1,0 +1,11 @@
+import { base } from '$app/paths'
+
+function getPathFromBase(path: string) {
+  if (path === '/')
+    return ''
+  if (!base)
+    return path
+  return `${base}${path}`
+}
+
+export { getPathFromBase }


### PR DESCRIPTION
Hey,

this is an example of a potential solution for problem mentioned in #159. However be cautious, my pre-commit checks failed, but all tests passed, but anyways, I wanted to propose my solution. (feel free to reject)

I streamlined parsing the path with function `getPathFromBase`, all expressive URI connects in components were replaced by this declarative approach.

What my solution is lacking is rewriting src for user defined images which seems like more complicated issue, for separate discussion.