### PR TITLE
feat(theme-blog): morph view transitions from card to post hero

### DIFF
--- a/.changeset/blog-view-transitions.md
+++ b/.changeset/blog-view-transitions.md
@@ -2,4 +2,4 @@
 '@sveltepress/theme-blog': minor
 ---
 
-Morph card → post-hero animations via the native View Transitions API. The cover image and title on each post card now share a `view-transition-name` with the corresponding elements on the post page, so SvelteKit navigations animate the clicked card to its detail-page location. Feature-detected and respects `prefers-reduced-motion`.
+Morph card ↔ post-hero animations via the native View Transitions API. The cover, title, first tag, date, and reading-time on each post card now share a `view-transition-name` with the corresponding elements on the post page, so SvelteKit navigations animate the clicked card to its detail-page location — and animate back when the user returns to the listing. Feature-detected and respects `prefers-reduced-motion`.

--- a/.changeset/blog-view-transitions.md
+++ b/.changeset/blog-view-transitions.md
@@ -2,4 +2,8 @@
 '@sveltepress/theme-blog': minor
 ---
 
-Morph card ↔ post-hero animations via the native View Transitions API. The cover, title, first tag, date, and reading-time on each post card now share a `view-transition-name` with the corresponding elements on the post page, so SvelteKit navigations animate the clicked card to its detail-page location — and animate back when the user returns to the listing. Feature-detected and respects `prefers-reduced-motion`.
+Morph card ↔ post-hero animations via the native View Transitions API. The cover, title, first tag, date, reading-time, and excerpt on each post card now share a `view-transition-name` with the corresponding elements on the post page, so SvelteKit navigations animate the clicked card to its detail-page location — and animate back when the user returns to the listing. `PostHero` gains a small deck/subtitle that echoes `post.excerpt` so the card excerpt has a matching morph target. Feature-detected and respects `prefers-reduced-motion`.
+
+The cover `view-transition-name` lives on an always-sized wrapper div (rather than the `<img>` itself), so back-navigation still morphs even when the freshly-remounted image has not yet produced a layout box at capture time.
+
+On back-navigation, `GlobalLayout` temporarily toggles `html.sp-vt-active` around each cross-document transition and a global CSS rule flips `.sp-card-large` / `.sp-card-small` out of `content-visibility: auto` for the duration. Without this, off-viewport cards were still skipped when the browser captured the "new" snapshot — their shared `view-transition-name` elements were missing from the capture, and the reverse morph degraded to a root crossfade. The class is cleared on `transition.finished`, so the lazy-render behavior resumes immediately after the animation.

--- a/.changeset/blog-view-transitions.md
+++ b/.changeset/blog-view-transitions.md
@@ -1,0 +1,5 @@
+---
+'@sveltepress/theme-blog': minor
+---
+
+Morph card → post-hero animations via the native View Transitions API. The cover image and title on each post card now share a `view-transition-name` with the corresponding elements on the post page, so SvelteKit navigations animate the clicked card to its detail-page location. Feature-detected and respects `prefers-reduced-motion`.

--- a/packages/example-blog/static/rss.xml
+++ b/packages/example-blog/static/rss.xml
@@ -4,7 +4,7 @@
     <title>Example Blog</title>
     <link>http://localhost:4173</link>
     <description>A demo blog powered by @sveltepress/theme-blog</description>
-    <lastBuildDate>Thu, 16 Apr 2026 19:21:17 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 17 Apr 2026 05:01:31 GMT</lastBuildDate>
     <copyright>© 2026 Example Blog</copyright>
     
     <item>

--- a/packages/theme-blog/src/components/GlobalLayout.svelte
+++ b/packages/theme-blog/src/components/GlobalLayout.svelte
@@ -1,6 +1,7 @@
 <!-- src/components/GlobalLayout.svelte -->
 <script lang="ts">
   import type { Snippet } from 'svelte'
+  import { onNavigate } from '$app/navigation'
   import { base } from '$app/paths'
   import { blogConfig } from 'virtual:sveltepress/blog-config'
   import SearchModal from './SearchModal.svelte'
@@ -18,6 +19,27 @@
   // `blogConfig.base` when set, else fall back to the subpath base.
   const ogOrigin = blogConfig.base?.replace(/\/$/, '') ?? base
   const ogHome = `${ogOrigin}/og/__home.png`
+
+  // Cross-document view transitions. When the browser supports it and the
+  // user hasn't opted out of motion, wrap each SvelteKit navigation in a
+  // `document.startViewTransition` so elements sharing a `view-transition-name`
+  // (card cover ↔ post hero, card title ↔ post title) morph between pages.
+  onNavigate(navigation => {
+    if (typeof document === 'undefined') return
+    const start = (
+      document as Document & {
+        startViewTransition?: (cb: () => void | Promise<void>) => unknown
+      }
+    ).startViewTransition
+    if (!start) return
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return
+    return new Promise<void>(resolve => {
+      start.call(document, async () => {
+        resolve()
+        await navigation.complete
+      })
+    })
+  })
 
   let searchOpen = $state(false)
 
@@ -398,5 +420,22 @@
     font-size: 0.875rem;
     color: var(--sp-blog-muted);
     opacity: 0.5;
+  }
+
+  /* ── View Transitions — card ↔ post morph ───────────────── */
+  :global(::view-transition-group(*)) {
+    animation-duration: 420ms;
+    animation-timing-function: cubic-bezier(0.2, 0, 0.2, 1);
+  }
+  :global(::view-transition-old(root)),
+  :global(::view-transition-new(root)) {
+    animation-duration: 260ms;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    :global(::view-transition-group(*)),
+    :global(::view-transition-old(root)),
+    :global(::view-transition-new(root)) {
+      animation: none !important;
+    }
   }
 </style>

--- a/packages/theme-blog/src/components/GlobalLayout.svelte
+++ b/packages/theme-blog/src/components/GlobalLayout.svelte
@@ -24,20 +24,33 @@
   // user hasn't opted out of motion, wrap each SvelteKit navigation in a
   // `document.startViewTransition` so elements sharing a `view-transition-name`
   // (card cover ↔ post hero, card title ↔ post title) morph between pages.
+  //
+  // We toggle `html.sp-vt-active` around the transition because the masonry
+  // cards use `content-visibility: auto`. On back-nav the "new" snapshot is
+  // captured before those off-viewport cards get promoted to rendered, so
+  // their `view-transition-name` elements are absent from the capture and
+  // the morph falls back to a root crossfade. The class lets a global CSS
+  // rule force `content-visibility: visible` for the window of the VT.
   onNavigate(navigation => {
     if (typeof document === 'undefined') return
     const start = (
       document as Document & {
-        startViewTransition?: (cb: () => void | Promise<void>) => unknown
+        startViewTransition?: (cb: () => void | Promise<void>) => {
+          finished: Promise<void>
+        }
       }
     ).startViewTransition
     if (!start) return
     if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return
+    const root = document.documentElement
+    root.classList.add('sp-vt-active')
+    const clear = () => root.classList.remove('sp-vt-active')
     return new Promise<void>(resolve => {
-      start.call(document, async () => {
+      const transition = start.call(document, async () => {
         resolve()
         await navigation.complete
       })
+      transition.finished.then(clear, clear)
     })
   })
 
@@ -430,6 +443,13 @@
   :global(::view-transition-old(root)),
   :global(::view-transition-new(root)) {
     animation-duration: 260ms;
+  }
+  /* Force the lazy-rendered cards to a rendered state while a cross-doc
+     VT is in flight so their `view-transition-name` elements participate
+     in the "new" snapshot on back-nav. See `onNavigate` above. */
+  :global(html.sp-vt-active .sp-card-large),
+  :global(html.sp-vt-active .sp-card-small) {
+    content-visibility: visible;
   }
   @media (prefers-reduced-motion: reduce) {
     :global(::view-transition-group(*)),

--- a/packages/theme-blog/src/components/PostCardFeatured.svelte
+++ b/packages/theme-blog/src/components/PostCardFeatured.svelte
@@ -28,7 +28,11 @@
     >
       <div class="sp-card-featured__overlay">
         {#if post.tags[0]}
-          <span class="sp-card-featured__tag">{post.tags[0]}</span>
+          <span
+            class="sp-card-featured__tag"
+            style="view-transition-name: sp-tag-{post.slug}"
+            >{post.tags[0]}</span
+          >
         {/if}
         <h2
           class="sp-card-featured__title"
@@ -38,8 +42,12 @@
         </h2>
         <p class="sp-card-featured__excerpt">{post.excerpt}</p>
         <div class="sp-card__meta sp-card__meta--light">
-          <time>{post.date}</time>
-          <span>{post.readingTime} min read</span>
+          <time style="view-transition-name: sp-date-{post.slug}"
+            >{post.date}</time
+          >
+          <span style="view-transition-name: sp-reading-{post.slug}"
+            >{post.readingTime} min read</span
+          >
         </div>
       </div>
     </div>

--- a/packages/theme-blog/src/components/PostCardFeatured.svelte
+++ b/packages/theme-blog/src/components/PostCardFeatured.svelte
@@ -27,12 +27,15 @@
       }; view-transition-name: sp-cover-${post.slug}`}
     >
       <div class="sp-card-featured__overlay">
-        {#if post.tags[0]}
-          <span
-            class="sp-card-featured__tag"
-            style="view-transition-name: sp-tag-{post.slug}"
-            >{post.tags[0]}</span
-          >
+        {#if post.tags.length}
+          <div class="sp-card-featured__tags">
+            {#each post.tags as tag, i (tag)}
+              <span
+                class="sp-card-featured__tag"
+                style="view-transition-name: sp-tag-{post.slug}-{i}">{tag}</span
+              >
+            {/each}
+          </div>
         {/if}
         <h2
           class="sp-card-featured__title"
@@ -40,7 +43,12 @@
         >
           {post.title}
         </h2>
-        <p class="sp-card-featured__excerpt">{post.excerpt}</p>
+        <p
+          class="sp-card-featured__excerpt"
+          style="view-transition-name: sp-excerpt-{post.slug}"
+        >
+          {post.excerpt}
+        </p>
         <div class="sp-card__meta sp-card__meta--light">
           <time style="view-transition-name: sp-date-{post.slug}"
             >{post.date}</time
@@ -86,6 +94,12 @@
     justify-content: flex-end;
     padding: 1.25rem;
   }
+  .sp-card-featured__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-bottom: 0.5rem;
+  }
   .sp-card-featured__tag {
     font-size: 0.7rem;
     font-weight: 700;
@@ -95,8 +109,6 @@
     background: rgba(234, 88, 12, 0.35);
     padding: 2px 8px;
     border-radius: 3px;
-    display: inline-block;
-    margin-bottom: 0.5rem;
     width: fit-content;
   }
   .sp-card-featured__title {

--- a/packages/theme-blog/src/components/PostCardFeatured.svelte
+++ b/packages/theme-blog/src/components/PostCardFeatured.svelte
@@ -20,15 +20,22 @@
   <a href={`${base}/posts/${post.slug}/`} class="sp-card-featured__link">
     <div
       class="sp-card-featured__bg"
-      style={coverSrc
-        ? `background-image:url(${coverSrc})`
-        : 'background:linear-gradient(135deg,#ea580c 0%,#dc2626 50%,#9a3412 100%)'}
+      style={`${
+        coverSrc
+          ? `background-image:url(${coverSrc})`
+          : 'background:linear-gradient(135deg,#ea580c 0%,#dc2626 50%,#9a3412 100%)'
+      }; view-transition-name: sp-cover-${post.slug}`}
     >
       <div class="sp-card-featured__overlay">
         {#if post.tags[0]}
           <span class="sp-card-featured__tag">{post.tags[0]}</span>
         {/if}
-        <h2 class="sp-card-featured__title">{post.title}</h2>
+        <h2
+          class="sp-card-featured__title"
+          style="view-transition-name: sp-title-{post.slug}"
+        >
+          {post.title}
+        </h2>
         <p class="sp-card-featured__excerpt">{post.excerpt}</p>
         <div class="sp-card__meta sp-card__meta--light">
           <time>{post.date}</time>

--- a/packages/theme-blog/src/components/PostCardLarge.svelte
+++ b/packages/theme-blog/src/components/PostCardLarge.svelte
@@ -37,29 +37,42 @@
 
 <article class="sp-card-large">
   <a href={`${base}/posts/${post.slug}/`} class="sp-card-large__link">
-    {#if post.cover}
-      <img
-        src={coverSrc}
-        alt={post.title}
-        class="sp-card-large__cover"
-        width="800"
-        height="400"
-        loading="lazy"
-        decoding="async"
-        style="view-transition-name: sp-cover-{post.slug}"
-      />
-    {:else}
-      <div
-        class="sp-card-large__cover sp-card-large__cover--gradient"
-        style="background:{gradient}; view-transition-name: sp-cover-{post.slug}"
-      ></div>
-    {/if}
+    <!--
+      view-transition-name goes on this frame, not the <img>: on back-nav
+      the freshly-rendered <img> reports a 0×0 rect at VT capture time, so
+      a name on the image falls back to crossfade instead of morphing.
+    -->
+    <div
+      class="sp-card-large__cover-frame"
+      style="view-transition-name: sp-cover-{post.slug}"
+    >
+      {#if post.cover}
+        <img
+          src={coverSrc}
+          alt={post.title}
+          class="sp-card-large__cover"
+          width="800"
+          height="400"
+          loading="lazy"
+          decoding="async"
+        />
+      {:else}
+        <div
+          class="sp-card-large__cover sp-card-large__cover--gradient"
+          style="background:{gradient}"
+        ></div>
+      {/if}
+    </div>
     <div class="sp-card-large__body">
-      {#if post.tags[0]}
-        <span
-          class="sp-card__tag"
-          style="view-transition-name: sp-tag-{post.slug}">{post.tags[0]}</span
-        >
+      {#if post.tags.length}
+        <div class="sp-card__tags">
+          {#each post.tags as tag, i (tag)}
+            <span
+              class="sp-card__tag"
+              style="view-transition-name: sp-tag-{post.slug}-{i}">{tag}</span
+            >
+          {/each}
+        </div>
       {/if}
       <h2
         class="sp-card-large__title"
@@ -67,7 +80,12 @@
       >
         {post.title}
       </h2>
-      <p class="sp-card-large__excerpt">{post.excerpt}</p>
+      <p
+        class="sp-card-large__excerpt"
+        style="view-transition-name: sp-excerpt-{post.slug}"
+      >
+        {post.excerpt}
+      </p>
       <div class="sp-card__meta">
         <time style="view-transition-name: sp-date-{post.slug}"
           >{post.date}</time
@@ -99,13 +117,20 @@
     text-decoration: none;
     color: inherit;
   }
-  .sp-card-large__cover {
+  .sp-card-large__cover-frame {
     width: 100%;
     height: 180px;
+    overflow: hidden;
+  }
+  .sp-card-large__cover {
+    width: 100%;
+    height: 100%;
     object-fit: cover;
     display: block;
   }
   .sp-card-large__cover--gradient {
+    width: 100%;
+    height: 100%;
   }
   .sp-card-large__body {
     padding: 1rem;
@@ -121,6 +146,11 @@
     font-size: 0.825rem;
     color: var(--sp-blog-muted);
     line-height: 1.55;
+  }
+  .sp-card__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
   }
   .sp-card__tag {
     font-size: 0.7rem;

--- a/packages/theme-blog/src/components/PostCardLarge.svelte
+++ b/packages/theme-blog/src/components/PostCardLarge.svelte
@@ -56,7 +56,10 @@
     {/if}
     <div class="sp-card-large__body">
       {#if post.tags[0]}
-        <span class="sp-card__tag">{post.tags[0]}</span>
+        <span
+          class="sp-card__tag"
+          style="view-transition-name: sp-tag-{post.slug}">{post.tags[0]}</span
+        >
       {/if}
       <h2
         class="sp-card-large__title"
@@ -66,8 +69,12 @@
       </h2>
       <p class="sp-card-large__excerpt">{post.excerpt}</p>
       <div class="sp-card__meta">
-        <time>{post.date}</time>
-        <span>{post.readingTime} min read</span>
+        <time style="view-transition-name: sp-date-{post.slug}"
+          >{post.date}</time
+        >
+        <span style="view-transition-name: sp-reading-{post.slug}"
+          >{post.readingTime} min read</span
+        >
       </div>
     </div>
   </a>

--- a/packages/theme-blog/src/components/PostCardLarge.svelte
+++ b/packages/theme-blog/src/components/PostCardLarge.svelte
@@ -46,18 +46,24 @@
         height="400"
         loading="lazy"
         decoding="async"
+        style="view-transition-name: sp-cover-{post.slug}"
       />
     {:else}
       <div
         class="sp-card-large__cover sp-card-large__cover--gradient"
-        style="background:{gradient}"
+        style="background:{gradient}; view-transition-name: sp-cover-{post.slug}"
       ></div>
     {/if}
     <div class="sp-card-large__body">
       {#if post.tags[0]}
         <span class="sp-card__tag">{post.tags[0]}</span>
       {/if}
-      <h2 class="sp-card-large__title">{post.title}</h2>
+      <h2
+        class="sp-card-large__title"
+        style="view-transition-name: sp-title-{post.slug}"
+      >
+        {post.title}
+      </h2>
       <p class="sp-card-large__excerpt">{post.excerpt}</p>
       <div class="sp-card__meta">
         <time>{post.date}</time>

--- a/packages/theme-blog/src/components/PostCardSmall.svelte
+++ b/packages/theme-blog/src/components/PostCardSmall.svelte
@@ -15,7 +15,12 @@
     {#if post.tags[0]}
       <span class="sp-card__tag">{post.tags[0]}</span>
     {/if}
-    <h2 class="sp-card-small__title">{post.title}</h2>
+    <h2
+      class="sp-card-small__title"
+      style="view-transition-name: sp-title-{post.slug}"
+    >
+      {post.title}
+    </h2>
     <p class="sp-card-small__quote">{post.excerpt}</p>
     <div class="sp-card__meta">
       <time>{post.date}</time>

--- a/packages/theme-blog/src/components/PostCardSmall.svelte
+++ b/packages/theme-blog/src/components/PostCardSmall.svelte
@@ -12,11 +12,15 @@
 
 <article class="sp-card-small">
   <a href={`${base}/posts/${post.slug}/`} class="sp-card-small__link">
-    {#if post.tags[0]}
-      <span
-        class="sp-card__tag"
-        style="view-transition-name: sp-tag-{post.slug}">{post.tags[0]}</span
-      >
+    {#if post.tags.length}
+      <div class="sp-card__tags">
+        {#each post.tags as tag, i (tag)}
+          <span
+            class="sp-card__tag"
+            style="view-transition-name: sp-tag-{post.slug}-{i}">{tag}</span
+          >
+        {/each}
+      </div>
     {/if}
     <h2
       class="sp-card-small__title"
@@ -24,7 +28,12 @@
     >
       {post.title}
     </h2>
-    <p class="sp-card-small__quote">{post.excerpt}</p>
+    <p
+      class="sp-card-small__quote"
+      style="view-transition-name: sp-excerpt-{post.slug}"
+    >
+      {post.excerpt}
+    </p>
     <div class="sp-card__meta">
       <time style="view-transition-name: sp-date-{post.slug}">{post.date}</time>
       <span style="view-transition-name: sp-reading-{post.slug}"
@@ -66,6 +75,11 @@
     font-size: 0.8rem;
     color: var(--sp-blog-muted);
     line-height: 1.5;
+  }
+  .sp-card__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
   }
   .sp-card__tag {
     font-size: 0.7rem;

--- a/packages/theme-blog/src/components/PostCardSmall.svelte
+++ b/packages/theme-blog/src/components/PostCardSmall.svelte
@@ -13,7 +13,10 @@
 <article class="sp-card-small">
   <a href={`${base}/posts/${post.slug}/`} class="sp-card-small__link">
     {#if post.tags[0]}
-      <span class="sp-card__tag">{post.tags[0]}</span>
+      <span
+        class="sp-card__tag"
+        style="view-transition-name: sp-tag-{post.slug}">{post.tags[0]}</span
+      >
     {/if}
     <h2
       class="sp-card-small__title"
@@ -23,8 +26,10 @@
     </h2>
     <p class="sp-card-small__quote">{post.excerpt}</p>
     <div class="sp-card__meta">
-      <time>{post.date}</time>
-      <span>{post.readingTime} min read</span>
+      <time style="view-transition-name: sp-date-{post.slug}">{post.date}</time>
+      <span style="view-transition-name: sp-reading-{post.slug}"
+        >{post.readingTime} min read</span
+      >
     </div>
   </a>
 </article>

--- a/packages/theme-blog/src/components/PostHero.svelte
+++ b/packages/theme-blog/src/components/PostHero.svelte
@@ -30,6 +30,12 @@
     >
       {post.title}
     </h1>
+    <p
+      class="sp-post-hero__subtitle"
+      style="view-transition-name: sp-excerpt-{post.slug}"
+    >
+      {post.excerpt}
+    </p>
   </div>
 </header>
 
@@ -74,5 +80,16 @@
     color: #fff7ed;
     line-height: 1.2;
     letter-spacing: -0.02em;
+  }
+  .sp-post-hero__subtitle {
+    margin-top: 0.75rem;
+    max-width: 52ch;
+    font-size: clamp(0.9rem, 1.4vw, 1rem);
+    font-weight: 400;
+    color: #fde8c8;
+    line-height: 1.55;
+  }
+  .sp-post-hero__subtitle:empty {
+    display: none;
   }
 </style>

--- a/packages/theme-blog/src/components/PostHero.svelte
+++ b/packages/theme-blog/src/components/PostHero.svelte
@@ -18,13 +18,18 @@
 
 <header
   class="sp-post-hero"
-  style={coverSrc ? `--hero-bg: url(${coverSrc})` : ''}
+  style={`${coverSrc ? `--hero-bg: url(${coverSrc});` : ''} view-transition-name: sp-cover-${post.slug}`}
 >
   <div class="sp-post-hero__overlay">
     {#if post.category}
       <span class="sp-post-hero__cat">{post.category}</span>
     {/if}
-    <h1 class="sp-post-hero__title">{post.title}</h1>
+    <h1
+      class="sp-post-hero__title"
+      style="view-transition-name: sp-title-{post.slug}"
+    >
+      {post.title}
+    </h1>
   </div>
 </header>
 

--- a/packages/theme-blog/src/components/PostMeta.svelte
+++ b/packages/theme-blog/src/components/PostMeta.svelte
@@ -15,14 +15,25 @@
     <span class="sp-post-meta__author">{post.author}</span>
     <span class="sp-post-meta__sep">·</span>
   {/if}
-  <time class="sp-post-meta__date">{post.date}</time>
+  <time
+    class="sp-post-meta__date"
+    style="view-transition-name: sp-date-{post.slug}">{post.date}</time
+  >
   <span class="sp-post-meta__sep">·</span>
-  <span>{post.readingTime} min read</span>
+  <span style="view-transition-name: sp-reading-{post.slug}"
+    >{post.readingTime} min read</span
+  >
   {#if post.tags.length}
     <span class="sp-post-meta__sep">·</span>
     <div class="sp-post-meta__tags">
-      {#each post.tags as tag}
-        <a href={`${base}/tags/${tag}/`} class="sp-post-meta__tag">{tag}</a>
+      {#each post.tags as tag, i}
+        <a
+          href={`${base}/tags/${tag}/`}
+          class="sp-post-meta__tag"
+          style={i === 0
+            ? `view-transition-name: sp-tag-${post.slug}`
+            : undefined}>{tag}</a
+        >
       {/each}
     </div>
   {/if}

--- a/packages/theme-blog/src/components/PostMeta.svelte
+++ b/packages/theme-blog/src/components/PostMeta.svelte
@@ -26,13 +26,11 @@
   {#if post.tags.length}
     <span class="sp-post-meta__sep">·</span>
     <div class="sp-post-meta__tags">
-      {#each post.tags as tag, i}
+      {#each post.tags as tag, i (tag)}
         <a
           href={`${base}/tags/${tag}/`}
           class="sp-post-meta__tag"
-          style={i === 0
-            ? `view-transition-name: sp-tag-${post.slug}`
-            : undefined}>{tag}</a
+          style="view-transition-name: sp-tag-{post.slug}-{i}">{tag}</a
         >
       {/each}
     </div>


### PR DESCRIPTION
## Summary
- Animate the clicked post card's cover and title into their positions on the post page using the native View Transitions API
- `onNavigate` in `GlobalLayout.svelte` wraps each SvelteKit navigation in `document.startViewTransition`; cards and hero share a per-slug `view-transition-name`
- Feature-detected (noop where unsupported) and gated behind `prefers-reduced-motion`

## Test plan
- [x] Verified `sp-cover-<slug>` / `sp-title-<slug>` match between home cards and post hero (`agent-browser eval`)
- [x] Confirmed `document.startViewTransition` fires exactly once per card click via a runtime hook
- [x] Confirmed CSS rules `::view-transition-group(*)`, `::view-transition-old(root)`, `::view-transition-new(root)` plus the `prefers-reduced-motion` guard are emitted
- [x] `pnpm --filter @sveltepress/theme-blog build` passes
- [x] `packages/example-blog` production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)