### PR TITLE
feat(vite): Support passing SvelteKit config via Vite plugin

### DIFF
--- a/.changeset/public-snails-march.md
+++ b/.changeset/public-snails-march.md
@@ -1,0 +1,5 @@
+---
+'@sveltepress/vite': minor
+---
+
+feat: Support passing SvelteKit config via Vite plugin

--- a/packages/docs-site/src/routes/reference/vite-plugin/+page.md
+++ b/packages/docs-site/src/routes/reference/vite-plugin/+page.md
@@ -11,7 +11,7 @@ title: Vite plugin
 ### `siteConfig`
 
 * `title`: The site's title. Would be `'Untitled site'` if not provided.
-* `description`: The site's description. Would be `'Build by sveltepress'` if not provided.
+* `description`: The site's description. Would be `'Built by SveltePress'` if not provided.
 
 ### `addInspect`
 
@@ -58,6 +58,15 @@ export default defineConfig({
 
 The rehype plugins used for html generator.
 Read [Rehype plugins](https://github.com/rehypejs/rehype#plugins) for more details.
+
+### SvelteKit options
+
+As of SvelteKit version 2.62.0, it has been possible to pass the SvelteKit
+[configuration](https://svelte.dev/docs/kit/configuration) directly to the
+[SvelteKit Vite plugin](https://svelte.dev/docs/kit/@sveltejs-kit-vite).
+
+This is also supported by the `sveltepress` plugin. Omitting the need for
+a `svelte.config.js` file completely.
 
 ## ResolvedTheme
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,3 +1,4 @@
+import type { KitConfig } from '@sveltejs/kit'
 import type { PluginOption } from 'vite'
 import type { Highlighter, LlmsConfig, LoadTheme, ResolvedTheme, SiteConfig, SveltepressVitePluginOptions, ThemeVitePlugins } from './types.js'
 import { enhancedImages } from '@sveltejs/enhanced-img'
@@ -8,20 +9,27 @@ import SveltepressVitePlugin from './plugin.js'
 
 export * as log from './utils/log.js'
 
-const sveltepress: (options?: SveltepressVitePluginOptions) => PluginOption = async ({
+/**
+ * Returns the SveltePress Vite plugins.
+ * You can also pass the SvelteKit configuration directly to this plugin,
+ * in which case `svelte.config.js` is ignored.
+ */
+const sveltepress: (options?: SveltepressVitePluginOptions & KitConfig) => PluginOption = async ({
   theme,
   addInspect,
   siteConfig,
   remarkPlugins,
   rehypePlugins,
   llms,
+  ...kitConfig
 } = {
   addInspect: false,
 }) => {
   const requiredSiteConfig: Required<SiteConfig> = {
     title: siteConfig?.title || 'Untitled site',
-    description: siteConfig?.description || 'Build by Sveltepress',
+    description: siteConfig?.description || 'Built by SveltePress',
   }
+
   const corePlugin = [
     SveltepressVitePlugin({
       theme,
@@ -32,7 +40,7 @@ const sveltepress: (options?: SveltepressVitePluginOptions) => PluginOption = as
     }),
     // must come before sveltekit, and after sveltepress
     enhancedImages(),
-    sveltekit(),
+    sveltekit((Object.keys(kitConfig).length > 0) ? kitConfig : undefined),
   ]
 
   const plugins = typeof theme?.vitePlugins === 'function'


### PR DESCRIPTION
As Svelte(Kit) supports [passing the config directly to the Vite plugin](https://svelte.dev/docs/kit/@sveltejs-kit-vite), I added the same functionality to the `sveltepress` Vite plugin.

Ideally, this config approach would also be the default for the `create` template in the future, as well as updating the Quick Start docs.

---

_I have not created an issue for this prior to this PR, as it seemed like low effort to just implement it._

Since there are no tests covering the plugin itself (as far as I can tell), I did not really know how to go about adding a test for it...