### PR TITLE
feat(pwa): prefix precachePages and cap injectManifest runtime caches

### DIFF
--- a/.changeset/pwa-precache-prefixes.md
+++ b/.changeset/pwa-precache-prefixes.md
@@ -1,0 +1,10 @@
+---
+'@sveltepress/theme-default': minor
+---
+
+feat(pwa): allow precachePages URL prefixes and cap runtime caches
+
+Default remains homepage-only precache. `precachePages` now also accepts
+prefix strings (e.g. current locale / version). The injectManifest SW
+runtime-caches visited pages, `__data.json`, and images with expiration
+so versioned/i18n sites stay fast to update.

--- a/packages/docs-site/src/routes/bn/guide/default-theme/pwa/+page.md
+++ b/packages/docs-site/src/routes/bn/guide/default-theme/pwa/+page.md
@@ -36,6 +36,46 @@ export default config
 আপনার Vite project এ dev dependency হিসেবে `workbox-window` যুক্ত করতে হবে
 :::
 
+## HTML precache (versions & i18n)
+
+ডিফল্টভাবে Sveltepress শুধু **app shell** (JS / CSS / fonts) এবং **homepage** precache করে। বাকি ডকুমেন্টেশন পেজ ইউজার ভিজিট করলে runtime-এ cache হয় (`NetworkFirst`, সর্বোচ্চ 50টি এন্ট্রি)। ছবি এবং SvelteKit `__data.json`ও runtime cache হয়।
+
+অনেক version এবং locale থাকলে এটি service worker install/update দ্রুত রাখে। সব prerendered HTML precache করলে Workbox প্রতিবার `versions × locales × pages` hash, compare এবং download করে।
+
+### `pwa.precachePages`
+
+| Value | Precached HTML |
+| --- | --- |
+| `false` (default) | শুধু homepage |
+| `true` | সব prerendered HTML (historical version বাদ) |
+| `string[]` | Homepage + URL prefix |
+
+শুধু একটি locale এবং একটি version snapshot precache করতে:
+
+```ts
+import { defaultTheme } from '@sveltepress/theme-default'
+
+defaultTheme({
+  pwa: {
+    precachePages: ['/zh/', '/v/2026-08-27/'],
+  },
+})
+```
+
+আগের “সব পেজ cache করো” আচরণ ফিরিয়ে আনতে:
+
+```ts
+import { defaultTheme } from '@sveltepress/theme-default'
+
+defaultTheme({
+  pwa: {
+    precachePages: true,
+  },
+})
+```
+
+ভিজিট করা পেজ precache না থাকলেও runtime cache দিয়ে অফলাইনে খোলা যাবে।
+
 ## কনফিগের উদাহরণ
 
 এই সাইটের কনফিগ উদাহরণ হিসেবে দেখুন:

--- a/packages/docs-site/src/routes/guide/default-theme/pwa/+page.md
+++ b/packages/docs-site/src/routes/guide/default-theme/pwa/+page.md
@@ -36,6 +36,50 @@ If you want to enable pwa.
 You will need to add `workbox-window` as a dev dependency to your Vite project.
 :::
 
+## HTML precache (versions & i18n)
+
+By default Sveltepress only precaches the **app shell** (JS / CSS / fonts) and the **homepage**. Other documentation pages are cached at runtime when the user visits them (`NetworkFirst`, capped at 50 entries). Images and SvelteKit `__data.json` responses are also runtime-cached.
+
+This keeps service worker install and update fast when the site has many versions and locales. Precaching every prerendered HTML file makes Workbox hash, compare and download `versions × locales × pages` on every update.
+
+### `pwa.precachePages`
+
+| Value | Precached HTML |
+| --- | --- |
+| `false` (default) | Homepage only |
+| `true` | All prerendered HTML (historical versions are still ignored) |
+| `string[]` | Homepage + matching URL prefixes |
+
+Precache only the current locale and a version snapshot:
+
+```ts
+import { defaultTheme } from '@sveltepress/theme-default'
+
+defaultTheme({
+  pwa: {
+    precachePages: ['/zh/', '/v/2026-08-27/'],
+  },
+})
+```
+
+Restore the previous “cache every page” behavior:
+
+```ts
+import { defaultTheme } from '@sveltepress/theme-default'
+
+defaultTheme({
+  pwa: {
+    precachePages: true,
+  },
+})
+```
+
+:::tip
+A glob starting with `prerendered/` is always included. Otherwise `@vite-pwa/sveltekit` would append `prerendered/**/*.{html,json}` and pull every version/locale page back into the precache.
+:::
+
+Visited pages still work offline through the runtime cache, even when they are not precached.
+
 ## Example config
 
 Take the config this site use for example:

--- a/packages/docs-site/src/routes/zh/guide/default-theme/pwa/+page.md
+++ b/packages/docs-site/src/routes/zh/guide/default-theme/pwa/+page.md
@@ -38,6 +38,50 @@ export default config
 
 :::
 
+## HTML 预缓存（多版本 / 多语言）
+
+默认情况下，Sveltepress **只预缓存应用壳（JS / CSS / 字体）和首页**。其它文档页会在用户访问时按需写入运行时缓存（`NetworkFirst`，最多 50 条）。图片和 SvelteKit 的 `__data.json` 也会进入运行时缓存。
+
+这样在版本多、语言多时，Service Worker 的安装和更新仍然很快。如果把所有预渲染 HTML 都放进 precache，每次更新 Workbox 都要哈希、对比、下载 `版本 × 语言 × 页面` 的笛卡尔积。
+
+### `pwa.precachePages`
+
+| 取值 | 预缓存的 HTML |
+| --- | --- |
+| `false`（默认） | 仅首页 |
+| `true` | 全部预渲染 HTML（历史版本仍会被忽略） |
+| `string[]` | 首页 + 匹配的 URL 前缀 |
+
+只预缓存中文和某个版本快照：
+
+```ts
+import { defaultTheme } from '@sveltepress/theme-default'
+
+defaultTheme({
+  pwa: {
+    precachePages: ['/zh/', '/v/2026-08-27/'],
+  },
+})
+```
+
+恢复「缓存全部页面」的旧行为：
+
+```ts
+import { defaultTheme } from '@sveltepress/theme-default'
+
+defaultTheme({
+  pwa: {
+    precachePages: true,
+  },
+})
+```
+
+:::tip
+配置里必须保留一条以 `prerendered/` 开头的 glob。否则 `@vite-pwa/sveltekit` 会自动补上 `prerendered/**/*.{html,json}`，所有版本和语言的页面又会回到 precache。
+:::
+
+即使页面没有被预缓存，用户访问过的页面仍可通过运行时缓存离线打开。
+
 ## 配置示例
 
 用此站点使用的配置来举例：

--- a/packages/theme-default/__tests__/code-import.md
+++ b/packages/theme-default/__tests__/code-import.md
@@ -2,4 +2,4 @@
 
 @code(./fake-file.ts)
 
-@code(/src/index.ts,23,42)
+@code(/src/index.ts,24,43)

--- a/packages/theme-default/__tests__/import-code.test.ts
+++ b/packages/theme-default/__tests__/import-code.test.ts
@@ -19,7 +19,7 @@ describe('code import', async () => {
 
       @code(./fake-file.ts)
 
-      @code(/src/index.ts,23,42)
+      @code(/src/index.ts,24,43)
       "
     `)
 

--- a/packages/theme-default/__tests__/manifestless-bundle.test.ts
+++ b/packages/theme-default/__tests__/manifestless-bundle.test.ts
@@ -17,7 +17,7 @@ const reviewedManifestlessHashes = {
   'SidebarGroup.svelte': '5c30e45e371b667aac36e65be5c950e4368bb79e7e69d4392fab35373652cf1f',
   'Toc.svelte': 'b260bce61dc3ce8af1c7fbb7d5f6e08f24c1df15dc3f91f6ef77f45253c93775',
   'layout.ts': '430ecf785cf02871acc04e3de954e37b92a0c2c4586329bef610b4a794df2eb9',
-  'pwa/sw.js': 'f750090ff5156db51fc141494ffedc8acfa947cc4440985f8759af2182d6d513',
+  'pwa/sw.js': 'b0de55ae0e12539aaddb8d48175d840c80f95f26dcfccf023a4f0ba86bd1d033',
 }
 
 describe('manifestless default theme', () => {

--- a/packages/theme-default/__tests__/pwa-options.test.ts
+++ b/packages/theme-default/__tests__/pwa-options.test.ts
@@ -124,6 +124,43 @@ describe('theme-default PWA configuration', () => {
     expect(navCaching).toBeUndefined()
   })
 
+  it('precaches selected URL prefixes via precachePages and still runtime-caches the rest', async () => {
+    capturedPwaOptions.length = 0
+    const { defaultTheme } = await import('../src/index')
+
+    const theme = defaultTheme({
+      pwa: {
+        scope: '/',
+        precachePages: ['/zh/', '/v/2026-08-27/'],
+      },
+    })
+
+    const dummyCore = { name: 'core-plugin' }
+    await (theme.vitePlugins as any)(dummyCore)
+
+    expect(capturedPwaOptions).toHaveLength(1)
+    const pwa = capturedPwaOptions[0]
+
+    expect(pwa.injectManifest.globPatterns).toEqual([
+      'client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}',
+      'prerendered/pages/index.html',
+      'prerendered/pages/zh.html',
+      'prerendered/pages/zh/**',
+      'prerendered/pages/v/2026-08-27.html',
+      'prerendered/pages/v/2026-08-27/**',
+    ])
+    const navCaching = pwa.workbox.runtimeCaching.find(
+      (rc: any) => rc.options?.cacheName === 'sveltepress-pages',
+    )
+    expect(navCaching).toBeDefined()
+    expect(pwa.workbox.runtimeCaching.some(
+      (rc: any) => rc.options?.cacheName === 'sveltepress-data',
+    )).toBe(true)
+    expect(pwa.workbox.runtimeCaching.some(
+      (rc: any) => rc.options?.cacheName === 'sveltepress-images',
+    )).toBe(true)
+  })
+
   it('preserves user custom runtimeCaching and overrides', async () => {
     capturedPwaOptions.length = 0
     const { defaultTheme } = await import('../src/index')
@@ -165,6 +202,8 @@ describe('theme-default PWA configuration', () => {
       'utf8',
     )
     expect(sw).toContain('allowlist: [/^\\/$/]')
+    expect(sw).toContain('workbox-expiration')
+    expect(sw).toContain('__data.json')
     expect(sw).not.toContain('import.meta.env.DEV')
   })
 })

--- a/packages/theme-default/__tests__/pwa-precache-pages.test.ts
+++ b/packages/theme-default/__tests__/pwa-precache-pages.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  prefixToPrerenderedGlobs,
+  PWA_ALL_HTML_GLOB,
+  PWA_CLIENT_GLOB,
+  PWA_HOME_GLOB,
+  resolvePrecacheGlobPatterns,
+  shouldRuntimeCachePages,
+} from '../src/pwa/precache-pages'
+
+describe('prefixToPrerenderedGlobs', () => {
+  it('maps homepage prefixes to the index.html glob', () => {
+    expect(prefixToPrerenderedGlobs('/')).toEqual([PWA_HOME_GLOB])
+    expect(prefixToPrerenderedGlobs('')).toEqual([PWA_HOME_GLOB])
+  })
+
+  it('maps a locale/version prefix to file + directory globs', () => {
+    expect(prefixToPrerenderedGlobs('/zh/')).toEqual([
+      'prerendered/pages/zh.html',
+      'prerendered/pages/zh/**',
+    ])
+    expect(prefixToPrerenderedGlobs('v/2026-08-27')).toEqual([
+      'prerendered/pages/v/2026-08-27.html',
+      'prerendered/pages/v/2026-08-27/**',
+    ])
+  })
+})
+
+describe('resolvePrecacheGlobPatterns', () => {
+  it('defaults to homepage-only HTML so versioned/i18n sites stay small', () => {
+    expect(resolvePrecacheGlobPatterns()).toEqual([PWA_CLIENT_GLOB, PWA_HOME_GLOB])
+    expect(resolvePrecacheGlobPatterns(false)).toEqual([PWA_CLIENT_GLOB, PWA_HOME_GLOB])
+  })
+
+  it('includes a prerendered/ glob so sveltekit-pwa does not add the catch-all', () => {
+    for (const value of [false, true, ['/zh/']] as const) {
+      expect(resolvePrecacheGlobPatterns(value).some(g => g.startsWith('prerendered/'))).toBe(true)
+    }
+  })
+
+  it('can restore the old full-precache behavior', () => {
+    expect(resolvePrecacheGlobPatterns(true)).toEqual([
+      PWA_CLIENT_GLOB,
+      PWA_ALL_HTML_GLOB,
+    ])
+  })
+
+  it('precaches homepage plus selected version/locale prefixes', () => {
+    expect(resolvePrecacheGlobPatterns(['/zh/', '/v/2026-08-27/'])).toEqual([
+      PWA_CLIENT_GLOB,
+      PWA_HOME_GLOB,
+      'prerendered/pages/zh.html',
+      'prerendered/pages/zh/**',
+      'prerendered/pages/v/2026-08-27.html',
+      'prerendered/pages/v/2026-08-27/**',
+    ])
+  })
+
+  it('deduplicates homepage when it is also listed as a prefix', () => {
+    const patterns = resolvePrecacheGlobPatterns(['/', '/zh/'])
+    expect(patterns.filter(g => g === PWA_HOME_GLOB)).toHaveLength(1)
+  })
+})
+
+describe('shouldRuntimeCachePages', () => {
+  it('runtime-caches pages unless every HTML file is already precached', () => {
+    expect(shouldRuntimeCachePages()).toBe(true)
+    expect(shouldRuntimeCachePages(false)).toBe(true)
+    expect(shouldRuntimeCachePages(['/zh/'])).toBe(true)
+    expect(shouldRuntimeCachePages(true)).toBe(false)
+  })
+})

--- a/packages/theme-default/package.json
+++ b/packages/theme-default/package.json
@@ -87,6 +87,7 @@
     "unist-util-visit": "catalog:",
     "unocss": "catalog:",
     "workbox-build": "catalog:",
+    "workbox-expiration": "catalog:",
     "workbox-precaching": "catalog:",
     "workbox-routing": "catalog:",
     "workbox-strategies": "catalog:"

--- a/packages/theme-default/src/components/pwa/sw.js
+++ b/packages/theme-default/src/components/pwa/sw.js
@@ -1,8 +1,9 @@
 // @ts-nocheck
 /* eslint-disable no-restricted-globals */
+import { ExpirationPlugin } from 'workbox-expiration'
 import { cleanupOutdatedCaches, createHandlerBoundToURL, precacheAndRoute, PrecacheFallbackPlugin } from 'workbox-precaching'
 import { NavigationRoute, registerRoute } from 'workbox-routing'
-import { NetworkFirst } from 'workbox-strategies'
+import { CacheFirst, NetworkFirst } from 'workbox-strategies'
 
 self.addEventListener('message', (event) => {
   if (event.data && event.data.type === 'SKIP_WAITING')
@@ -23,6 +24,15 @@ precacheAndRoute(entriesAfterProcessed)
 // clean old assets
 cleanupOutdatedCaches()
 
+const pageExpiration = {
+  maxEntries: 50,
+  maxAgeSeconds: 7 * 24 * 60 * 60,
+}
+
+function pageFallbackPlugin() {
+  return new PrecacheFallbackPlugin({ fallbackURL: '/' })
+}
+
 // Only the root route may fall back to the precached homepage. generateSW
 // and an unrestricted NavigationRoute would otherwise serve `/` on every
 // document-page refresh.
@@ -37,7 +47,11 @@ if (versionBase) {
     ({ request, url }) => request.mode === 'navigate' && url.pathname.startsWith(`${versionBase}/`),
     new NetworkFirst({
       cacheName: 'sveltepress-version-pages',
-      plugins: [new PrecacheFallbackPlugin({ fallbackURL: '/' })],
+      networkTimeoutSeconds: 3,
+      plugins: [
+        new ExpirationPlugin(pageExpiration),
+        pageFallbackPlugin(),
+      ],
     }),
   )
 }
@@ -46,7 +60,35 @@ registerRoute(
   ({ request }) => request.mode === 'navigate',
   new NetworkFirst({
     cacheName: 'sveltepress-pages',
-    plugins: [new PrecacheFallbackPlugin({ fallbackURL: '/' })],
+    networkTimeoutSeconds: 3,
+    plugins: [
+      new ExpirationPlugin(pageExpiration),
+      pageFallbackPlugin(),
+    ],
+  }),
+)
+
+registerRoute(
+  ({ url }) => url.pathname.includes('/__data.json'),
+  new NetworkFirst({
+    cacheName: 'sveltepress-data',
+    networkTimeoutSeconds: 3,
+    plugins: [
+      new ExpirationPlugin(pageExpiration),
+    ],
+  }),
+)
+
+registerRoute(
+  ({ request }) => request.destination === 'image',
+  new CacheFirst({
+    cacheName: 'sveltepress-images',
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 50,
+        maxAgeSeconds: 30 * 24 * 60 * 60,
+      }),
+    ],
   }),
 )
 

--- a/packages/theme-default/src/index.ts
+++ b/packages/theme-default/src/index.ts
@@ -21,8 +21,6 @@ import createPreCorePlugins from './vite-plugins/create-pre-core-plugins.js'
 export { generateSidebar, isAutoSidebarOptions } from './auto-sidebar.js'
 export type { AutoSidebarOptions } from './auto-sidebar.js'
 export { SERVICE_WORKER_PATH } from './constants.js'
-export { resolvePrecacheGlobPatterns } from './pwa/precache-pages.js'
-export type { PrecachePages } from './pwa/precache-pages.js'
 
 const VIRTUAL_PWA = 'virtual:pwa-info'
 const VIRTUAL_PWA_SVELTE_REGISTER = 'virtual:pwa-register/svelte'

--- a/packages/theme-default/src/index.ts
+++ b/packages/theme-default/src/index.ts
@@ -14,12 +14,15 @@ import installPkg from './markdown/install-pkg.js'
 import links from './markdown/links.js'
 import liveCode from './markdown/live-code.js'
 import versionChanges from './markdown/version-changes.js'
+import { resolvePrecacheGlobPatterns, shouldRuntimeCachePages } from './pwa/precache-pages.js'
 import { createVersionManifestReader } from './version-manifest.js'
 import createPreCorePlugins from './vite-plugins/create-pre-core-plugins.js'
 
 export { generateSidebar, isAutoSidebarOptions } from './auto-sidebar.js'
 export type { AutoSidebarOptions } from './auto-sidebar.js'
 export { SERVICE_WORKER_PATH } from './constants.js'
+export { resolvePrecacheGlobPatterns } from './pwa/precache-pages.js'
+export type { PrecachePages } from './pwa/precache-pages.js'
 
 const VIRTUAL_PWA = 'virtual:pwa-info'
 const VIRTUAL_PWA_SVELTE_REGISTER = 'virtual:pwa-register/svelte'
@@ -44,16 +47,13 @@ const defaultTheme: ThemeDefault = (options) => {
     if (options?.pwa) {
       const pwaOptions = options.pwa as SvelteKitPWAOptions & {
         darkManifest?: string
-        precachePages?: boolean
+        precachePages?: boolean | string[]
       } & Record<string, any>
-      const precachePages = Boolean(pwaOptions.precachePages)
+      const precachePages = pwaOptions.precachePages ?? false
       const historicalGlob = versionManifest
         ? `prerendered/pages/**${versionManifest.basePath}/**/*.html`
         : null
-      const defaultGlobPatterns = [
-        'client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}',
-        precachePages ? 'prerendered/**/*.html' : 'prerendered/pages/index.html',
-      ]
+      const defaultGlobPatterns = resolvePrecacheGlobPatterns(precachePages)
       const versionRuntimeCaching = versionManifest
         ? [{
             urlPattern: new RegExp(`^${versionManifest.basePath}/`),
@@ -61,22 +61,50 @@ const defaultTheme: ThemeDefault = (options) => {
             options: { cacheName: 'sveltepress-version-pages' },
           }]
         : []
-      const docPagesRuntimeCaching = !precachePages
+      const pageExpiration = {
+        maxEntries: 50,
+        maxAgeSeconds: 7 * 24 * 60 * 60,
+      }
+      const docPagesRuntimeCaching = shouldRuntimeCachePages(precachePages)
         ? [{
             urlPattern: ({ request }: any) => request.mode === 'navigate',
             handler: 'NetworkFirst' as const,
             options: {
               cacheName: 'sveltepress-pages',
-              expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 7 * 24 * 60 * 60,
-              },
+              expiration: pageExpiration,
               cacheableResponse: {
                 statuses: [200],
               },
             },
           }]
         : []
+      const assetRuntimeCaching = [
+        {
+          urlPattern: ({ url }: any) => url.pathname.includes('/__data.json'),
+          handler: 'NetworkFirst' as const,
+          options: {
+            cacheName: 'sveltepress-data',
+            expiration: pageExpiration,
+            cacheableResponse: {
+              statuses: [200],
+            },
+          },
+        },
+        {
+          urlPattern: ({ request }: any) => request.destination === 'image',
+          handler: 'CacheFirst' as const,
+          options: {
+            cacheName: 'sveltepress-images',
+            expiration: {
+              maxEntries: 50,
+              maxAgeSeconds: 30 * 24 * 60 * 60,
+            },
+            cacheableResponse: {
+              statuses: [200],
+            },
+          },
+        },
+      ]
       plugins.push(SvelteKitPWA({
         strategies: 'injectManifest',
         srcDir: SERVICE_WORKER_PATH.replace(/sw\.js$/, ''),
@@ -107,6 +135,7 @@ const defaultTheme: ThemeDefault = (options) => {
             ...versionRuntimeCaching,
             ...(pwaOptions.workbox?.runtimeCaching ?? []),
             ...docPagesRuntimeCaching,
+            ...assetRuntimeCaching,
           ],
         },
       }))

--- a/packages/theme-default/src/pwa/precache-pages.ts
+++ b/packages/theme-default/src/pwa/precache-pages.ts
@@ -1,0 +1,54 @@
+/**
+ * Control which prerendered HTML files go into the Workbox precache.
+ *
+ * Default `false` only precaches the homepage so SW install/update stays
+ * cheap when the site has many versions and locales.
+ *
+ * - `false` / omitted: homepage only
+ * - `true`: every prerendered HTML file (except historical versions, which
+ *   are still glob-ignored)
+ * - `string[]`: homepage + URL prefixes, e.g. `['/zh/', '/v/2026-08-27/']`
+ */
+export type PrecachePages = boolean | string[]
+
+export const PWA_CLIENT_GLOB = 'client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}'
+export const PWA_HOME_GLOB = 'prerendered/pages/index.html'
+export const PWA_ALL_HTML_GLOB = 'prerendered/**/*.html'
+
+/**
+ * Map a site URL prefix to Workbox globs under `.svelte-kit/output`.
+ * `/zh/` -> `prerendered/pages/zh.html` + `prerendered/pages/zh/**`
+ */
+export function prefixToPrerenderedGlobs(prefix: string): string[] {
+  const clean = prefix.trim().replace(/^\/+/, '').replace(/\/+$/, '')
+  if (!clean)
+    return [PWA_HOME_GLOB]
+  return [
+    `prerendered/pages/${clean}.html`,
+    `prerendered/pages/${clean}/**`,
+  ]
+}
+
+/**
+ * Build `injectManifest` / `workbox` `globPatterns`.
+ *
+ * A glob starting with `prerendered/` MUST be present, otherwise
+ * `@vite-pwa/sveltekit` appends a catch-all for every prerendered HTML/JSON
+ * file and every version/locale page is hashed into the precache again.
+ */
+export function resolvePrecacheGlobPatterns(precachePages: PrecachePages = false): string[] {
+  if (precachePages === true)
+    return [PWA_CLIENT_GLOB, PWA_ALL_HTML_GLOB]
+
+  if (Array.isArray(precachePages)) {
+    const extra = precachePages.flatMap(prefixToPrerenderedGlobs)
+    return [...new Set([PWA_CLIENT_GLOB, PWA_HOME_GLOB, ...extra])]
+  }
+
+  return [PWA_CLIENT_GLOB, PWA_HOME_GLOB]
+}
+
+/** Runtime-cache visited pages unless every HTML file is already precached. */
+export function shouldRuntimeCachePages(precachePages: PrecachePages = false): boolean {
+  return precachePages !== true
+}

--- a/packages/theme-default/src/vite-plugins/strip-versioning.ts
+++ b/packages/theme-default/src/vite-plugins/strip-versioning.ts
@@ -87,7 +87,7 @@ const transforms: Record<string, SourceTransform> = {
     return replaceRequired(result, `  .item {\n    --at-apply: 'relative z-3 flex min-w-0 items-center cursor-pointer';\n    padding-left: calc(2.625rem + var(--heading-level) * 0.75rem);\n  }\n  .item-label {\n    --at-apply: 'min-w-0 truncate';\n  }`, `  .item {\n    --at-apply: 'relative z-3 block truncate cursor-pointer';\n    padding-left: calc(2.625rem + var(--heading-level) * 0.75rem);\n  }`)
   },
   'sw.js': (source) => {
-    return replaceRequired(source, `const versionBase = import.meta.env.SVELTEPRESS_VERSION_BASE\nif (versionBase) {\n  registerRoute(\n    ({ request, url }) => request.mode === 'navigate' && url.pathname.startsWith(\`${'${versionBase}'}/\`),\n    new NetworkFirst({\n      cacheName: 'sveltepress-version-pages',\n      plugins: [new PrecacheFallbackPlugin({ fallbackURL: '/' })],\n    }),\n  )\n}\n\n`)
+    return replaceRequired(source, `const versionBase = import.meta.env.SVELTEPRESS_VERSION_BASE\nif (versionBase) {\n  registerRoute(\n    ({ request, url }) => request.mode === 'navigate' && url.pathname.startsWith(\`${'${versionBase}'}/\`),\n    new NetworkFirst({\n      cacheName: 'sveltepress-version-pages',\n      networkTimeoutSeconds: 3,\n      plugins: [\n        new ExpirationPlugin(pageExpiration),\n        pageFallbackPlugin(),\n      ],\n    }),\n  )\n}\n\n`)
   },
 }
 

--- a/packages/theme-default/types.d.ts
+++ b/packages/theme-default/types.d.ts
@@ -49,7 +49,17 @@ declare module 'virtual:sveltepress/theme-default' {
     ga?: string
     pwa?: SvelteKitPWAOptions & {
       darkManifest?: string
-      precachePages?: boolean
+      /**
+       * Which prerendered HTML pages to put in the Workbox precache.
+       *
+       * Default `false` only precaches the homepage so service-worker
+       * install/update stays fast on sites with many versions and locales.
+       *
+       * - `false`: homepage only
+       * - `true`: all prerendered HTML (historical versions are still ignored)
+       * - `string[]`: URL prefixes, e.g. `['/zh/', '/v/2026-08-27/']`
+       */
+      precachePages?: boolean | string[]
     }
     docsearch?: Omit<DocSearchProps, 'container' | 'theme'>
     search?: Component | string | boolean

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ catalogs:
     vitest:
       specifier: 4.0.14
       version: 4.0.14
+    workbox-expiration:
+      specifier: ^7.4.1
+      version: 7.4.1
     workbox-precaching:
       specifier: ^7.4.1
       version: 7.4.1
@@ -683,6 +686,9 @@ importers:
         version: 66.10.0(@devframes/hub@0.9.12(crossws@0.4.12(srvx@1.0.3))(devframe@0.9.12(cac@7.0.0)(srvx@1.0.3)))(cac@7.0.0)(crossws@0.4.12(srvx@1.0.3))(rolldown@1.2.5)(rollup@4.53.3)(srvx@1.0.3)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.1)(tsx@4.20.6)(yaml@2.9.0))
       workbox-build:
         specifier: ^7.4.1
+        version: 7.4.1
+      workbox-expiration:
+        specifier: 'catalog:'
         version: 7.4.1
       workbox-precaching:
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -106,6 +106,7 @@ catalog:
   vite-plugin-inspect: ^11.4.1
   vitest: 4.0.14
   workbox-build: ^7.4.1
+  workbox-expiration: ^7.4.1
   workbox-precaching: ^7.4.1
   workbox-routing: ^7.4.1
   workbox-strategies: ^7.4.1


### PR DESCRIPTION
## Why

The earlier PWA work landed on the wrong repo (`Blackman99/sveltepress`). This ports the useful parts onto **this** repo without replacing the existing `precachePages` API.

Homepage-only precache was already the default here. What was still missing:

1. No way to precache **some** prefixes (current locale / version) without hashing every version × locale page
2. `injectManifest` `sw.js` runtime cache had **no expiration**, and did not cache `__data.json` or images (generateSW already had page expiration)

## Changes

`pwa.precachePages`:

| Value | Precached HTML |
| --- | --- |
| `false` (default) | Homepage only |
| `true` | All prerendered HTML (historical versions still glob-ignored) |
| `string[]` | Homepage + URL prefixes |

```ts
defaultTheme({
  pwa: {
    precachePages: ['/zh/', '/v/2026-08-27/'],
  },
})
```

Service worker:

- `ExpirationPlugin` on navigation / version page caches (50 entries, 7 days)
- `NetworkFirst` for `__data.json`
- `CacheFirst` for images
- Keep the root-only `NavigationRoute` allowlist so refreshes do not serve `/`

Docs updated in EN / ZH / BN. Tests cover glob resolution and the prefix option.