### PR TITLE
feat(pwa): shrink client precache so the refresh prompt appears sooner

### DIFF
--- a/.changeset/pwa-faster-update-prompt.md
+++ b/.changeset/pwa-faster-update-prompt.md
@@ -1,0 +1,5 @@
+---
+'@sveltepress/theme-default': minor
+---
+
+feat(pwa): default client precache to the app shell so the refresh prompt appears sooner on large docs sites. `precacheClient: true` restores the previous catch-all client glob.

--- a/docs/specs/pwa-faster-update-prompt.md
+++ b/docs/specs/pwa-faster-update-prompt.md
@@ -1,0 +1,153 @@
+# Spec: Faster PWA Refresh Prompt on Large Docs Sites
+
+Status: landing
+Branch: ship/pwa-faster-update-prompt
+Base-Commit: 84b431ade8731989d9996bafc92e98e2a5da6180
+Original-Branch: main
+
+## Requirement
+
+当文档站点的 PWA 检索资源过多，导致站点更新要很久才能弹出 paw refresh 的弹窗，优化
+
+## Problem Statement
+
+On a documentation site that enables the Default Theme PWA, a new deploy does not show the refresh toast until the new service worker finishes installing and reaches the `waiting` state. HTML precache is already homepage-only, but the default Workbox glob still matches every hashed client file under `.svelte-kit/output/client` — on the official docs site that is on the order of eight hundred files (hundreds of per-route SvelteKit nodes plus shared chunks, some several hundred kilobytes). Workbox must hash, compare, and download that set before `needRefresh` becomes true, so the “New content available” prompt appears long after the site has been updated.
+
+The toast itself is not the bottleneck. Users wait because install is too large.
+
+## Solution
+
+Shrink the default client precache to an app shell so the new service worker can become `waiting` quickly. Keep the existing click-to-reload toast: it still appears only after the worker is waiting; the user still clicks Reload. Per-route JavaScript and hashed chunks are no longer part of install. They are fetched when a route is visited and stored with a capped CacheFirst runtime cache. Sites that still want every client file in the precache opt in with `pwa.precacheClient: true`. `pwa.precachePages` continues to control HTML only.
+
+First-install homepage hydration may need the network (or a later visit that fills the runtime cache). Visited pages, including home after one online load, remain available offline through runtime caching.
+
+## Grill Decisions
+
+1. **Success criterion is a smaller precache, not toast chrome.** The delay is Workbox install of ~831 client files. Optimization is cutting per-route nodes and chunks out of the precache so `waiting` happens sooner. An “updating…” toast or auto-reload does not shrink install.
+2. **Applies to every Default Theme PWA site.** The glob lives in `@sveltepress/theme-default` and is used by both `injectManifest` (theme default) and `generateSW` (docs-site). Changing the theme default is the fix; a docs-site-only override would leave other large sites slow.
+3. **ReloadPrompt UX stays click-to-reload after waiting.** No auto-activate, no extra “updating…” state. The win is that `waiting` arrives sooner.
+4. **Default membership is app shell, not “keep chunks / drop nodes”.** Shared chunks still number in the hundreds and include large highlighter/twoslash files. Shell-only is the only cut that makes install cheap.
+5. **Escape hatch is a new flag, not a reuse of `precachePages`.** `pwa.precacheClient: true` restores today’s `client/**/*.{js,css,…}` glob. Default omitted/`false` is shell-only. HTML policy stays on `precachePages`.
+6. **Excluded hashed modules use CacheFirst.** `_app/immutable/**` URLs are content-hashed. CacheFirst with expiration is the runtime strategy. NetworkFirst would slow repeat visits; relying on HTTP cache alone would drop SW offline for those files.
+7. **Shell is defined by globs, not the Vite client manifest.** Vite marks every page node as an entry. The real start/app static graph is a handful of files, but Workbox only sees globs. Parsing `.vite/manifest.json` is out of scope. Default globs: entry JS/CSS, hashed CSS/fonts under assets, root icons. No `nodes/**`, no `chunks/**`.
+8. **First-install homepage hydration may need network.** Layout and homepage node modules are dynamic imports. They are not in the shell glob. After one online visit they live in the runtime cache.
+9. **Runtime cache cap is 400 entries and 30 days.** High enough that a heavy reading session does not immediately evict recent modules; low enough that unused hashes expire. Same 30-day age as the existing image cache.
+10. **The CacheFirst immutable rule is registered only when client precache is shell-only on generateSW.** When `precacheClient: true`, generateSW omits that runtime rule. The injectManifest service worker file is static, so it may still register CacheFirst; Workbox serves precache first, so the extra rule is redundant rather than wrong.
+
+## User Stories
+
+1. As a documentation reader on a PWA-enabled site, I want the refresh toast soon after a deploy, so that I can reload into new content without waiting for hundreds of unused page modules to download.
+2. As a documentation reader, I want to click Reload on that toast myself, so that a background update does not yank the page while I am reading.
+3. As a documentation reader who already visited a page online, I want that page’s hashed modules to be served from cache on later visits, so that repeat navigation stays fast and works offline.
+4. As a documentation reader who has never visited a given page, I want that page’s JavaScript fetched on demand, so that a site update does not download every locale and version module up front.
+5. As a documentation reader on first PWA install, I accept that homepage hydration may need the network until those modules have been cached, so that service-worker install stays small.
+6. As a site author using the Default Theme PWA, I want shell-only client precache by default, so that versioned and multilingual docs sites update promptly without extra config.
+7. As a site author who wants the previous “cache every client file” behavior, I want `pwa.precacheClient: true`, so that I can restore a fully precached client without forking Workbox globs by hand.
+8. As a site author who already configured `pwa.precachePages`, I want HTML precache policy unchanged, so that homepage-only / prefix / full-HTML choices keep working.
+9. As a site author using `generateSW` (as the official docs site does), I want the same shell glob and the same CacheFirst rule as `injectManifest` sites, so that strategy choice does not reintroduce a huge precache.
+10. As a site author who sets `precacheClient: true` with `generateSW`, I want the extra immutable CacheFirst rule omitted, so that runtime caching is not duplicated on top of a full client precache.
+11. As a docs reader of the PWA guide in English, Chinese, or Bengali, I want the new default and `precacheClient` documented, so that I know why install is small and how to restore the old client glob.
+
+## Implementation Decisions
+
+- Own the change in `@sveltepress/theme-default`. The official docs site keeps using the theme’s PWA defaults; it does not override client globs in its PWA config.
+- Extend the existing precache-pattern helper (the module that already builds `globPatterns` from `precachePages`) so it also takes `precacheClient` and returns the combined Workbox glob list. Keep HTML and client policies orthogonal: `precachePages` still decides prerendered HTML; `precacheClient` decides client files.
+- Default `precacheClient` is `false` / omitted. Shell client globs are:
+  - `client/_app/immutable/entry/**/*.{js,css}`
+  - `client/_app/immutable/assets/**/*.{css,otf,woff,woff2}`
+  - `client/*.{ico,png,svg,webp}`
+- `precacheClient: true` restores the current catch-all client glob `client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}`.
+- A glob starting with `prerendered/` remains mandatory so `@vite-pwa/sveltekit` does not append its catch-all HTML/JSON glob.
+- Do not parse the Vite client manifest. Do not special-case layout node `0` or the start/app chunk closure.
+- When client precache is shell-only, register a CacheFirst runtime rule for URLs whose pathname includes `/_app/immutable/`, cache name `sveltepress-immutable`, expiration `maxEntries: 400` and `maxAgeSeconds: 30 * 24 * 60 * 60`, cacheable status `200`. Place it with the existing runtime rules (after author `runtimeCaching`, alongside page/data/image rules).
+- When `precacheClient: true`, omit that runtime rule from `workbox.runtimeCaching` (generateSW). The injectManifest service worker source may keep a matching CacheFirst route unconditionally because that file is not parameterized; precache still wins for files already in `__WB_MANIFEST`.
+- `ReloadPrompt` / `Prompt` stay as they are: toast when `needRefresh` or `offlineReady`; Reload calls `updateServiceWorker(true)`.
+- Publish `precacheClient` on the Default Theme PWA options type next to `precachePages` and `darkManifest`.
+- Document the new default and the flag on the PWA guide in English, Chinese, and Bengali. Mention that first-install homepage hydration may need the network until hashed modules have been runtime-cached. Do not freeze a new docs version for this change; it is a current-docs clarification of existing PWA behavior.
+- Author a **minor** Changeset for `@sveltepress/theme-default` (new public option and a changed default, same class as `precachePages`).
+
+## Testing Decisions
+
+A good test here asserts the **public Workbox configuration** the theme hands to `@vite-pwa/sveltekit`, plus the static injectManifest service worker source — not Workbox internals, not a browser install, not Vite manifest parsing.
+
+**Seam (one):** the existing Default Theme PWA tests. They construct `defaultTheme({ pwa })`, run `vitePlugins` with a dummy core plugin, and inspect the captured `SvelteKitPWA` options (`injectManifest.globPatterns`, `workbox.globPatterns`, `workbox.runtimeCaching`). The injectManifest worker is asserted by reading the theme’s `sw.js` source. Extend that seam; do not add a second one.
+
+Prior art: `packages/theme-default/__tests__/pwa-options.test.ts` and `packages/theme-default/__tests__/pwa-precache-pages.test.ts`.
+
+Focused proofs:
+
+- Default globs include the three shell client patterns and homepage HTML, and **exclude** `client/**/*.{js,css,…}`, `nodes/**`, and `chunks/**`.
+- `precacheClient: true` restores the catch-all client glob.
+- `precachePages` still controls HTML independently of `precacheClient`.
+- Shell-only default registers CacheFirst `sveltepress-immutable` with 400 / 30-day expiration; `precacheClient: true` omits that rule from `workbox.runtimeCaching`.
+- `sw.js` registers CacheFirst for `_app/immutable` with the same cap.
+- Existing navigate-fallback and HTML-precache assertions remain green.
+- PWA guide pages in `/`, `/zh/`, and `/bn/` mention `precacheClient`.
+
+Do not require a Playwright service-worker install as an acceptance command: it is slow, environment-heavy, and not an existing seam.
+
+## Out of Scope
+
+- Changing ReloadPrompt copy, auto-reload, or an “updating…” intermediate toast.
+- Precaching Pagefind indexes, historical version HTML, or `__data.json`.
+- Parsing the Vite client manifest to include the start/app static chunk closure or layout node `0`.
+- Raising or removing runtime cache caps on pages, `__data.json`, or images.
+- Per-locale PWA manifests.
+- Freezing a new documentation version.
+- Changing `@vite-pwa/sveltekit` itself or requiring authors to switch strategies.
+
+## Acceptance Criteria
+
+1. Default client precache is shell-only and HTML remains homepage-only.
+   Command: `pnpm --filter @sveltepress/theme-default exec vitest run __tests__/pwa-precache-pages.test.ts __tests__/pwa-options.test.ts`
+   Pass: exit code 0; default `globPatterns` contain the entry / assets / root-icon globs and `prerendered/pages/index.html`, and do not contain `client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}` or a `nodes/**` / `chunks/**` glob.
+
+2. `precacheClient: true` restores the previous catch-all client glob; `precachePages` still selects HTML independently.
+   Command: same as criterion 1.
+   Pass: exit code 0; a case with `precacheClient: true` includes `client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}`; prefix / full HTML cases still match the existing `precachePages` contract.
+
+3. Shell-only generateSW registers CacheFirst for `/_app/immutable/` with 400 entries and 30-day max age; full client precache omits that workbox runtime rule.
+   Command: same as criterion 1.
+   Pass: exit code 0; default captured `workbox.runtimeCaching` includes `cacheName: 'sveltepress-immutable'` with those expiration values; `precacheClient: true` does not include that cache name.
+
+4. The injectManifest service worker registers CacheFirst for `_app/immutable` with the same cap.
+   Command: same as criterion 1 (the existing `sw.js` source assertion in `pwa-options.test.ts`).
+   Pass: exit code 0; `sw.js` contains `_app/immutable`, `CacheFirst`, `sveltepress-immutable`, `maxEntries: 400`.
+
+5. PWA guides in English, Chinese, and Bengali document `precacheClient`.
+   Command: `python3 -c "from pathlib import Path; roots=['packages/docs-site/src/routes/guide/default-theme/pwa/+page.md','packages/docs-site/src/routes/zh/guide/default-theme/pwa/+page.md','packages/docs-site/src/routes/bn/guide/default-theme/pwa/+page.md'];
+import sys
+missing=[p for p in roots if 'precacheClient' not in Path(p).read_text()]
+sys.exit(1 if missing else 0)"`
+   Pass: exit code 0 (every locale page contains `precacheClient`).
+
+6. Theme-default PWA tests and the repository test suite have no new failures versus baseline.
+   Command: `pnpm test`
+   Pass: exit code 0, or only failures already recorded in Baseline.
+
+The repository has no `pnpm run typecheck` script. Global guardrail for this change is `pnpm test`. Docs content check `pnpm check:docs:content` is run during landing if PWA guide pages change, but is not a named acceptance command beyond criterion 5.
+
+## Plan
+
+- [x] Ticket 1: Shell client precache glob — Delivers `precacheClient` on the glob helper and theme PWA options: default globs are entry + assets + root icons + existing HTML policy; `true` restores `client/**/*.{js,css,…}`; no nodes/chunks catch-all. Tests at pwa-precache-pages.test.ts and pwa-options.test.ts globPatterns. (Blocked by: none)
+- [ ] Ticket 2: Immutable CacheFirst runtime — Delivers generateSW `sveltepress-immutable` CacheFirst (400 / 30d) when shell-only, omitted when `precacheClient: true`; injectManifest `sw.js` registers the same route. Tests at pwa-options.test.ts runtimeCaching + sw.js source. (Blocked by: Ticket 1)
+- [ ] Ticket 3: Release & Documentation Compliance — Delivers Changeset (minor on `@sveltepress/theme-default`) and PWA guide updates in EN / ZH / BN documenting `precacheClient` and the first-install hydration tradeoff. Root README has no PWA glob section to update. (Blocked by: Tickets 1–2)
+
+## Ticket verification
+
+### Ticket 1 red proof
+
+`pnpm --filter @sveltepress/theme-default exec vitest run __tests__/pwa-precache-pages.test.ts __tests__/pwa-options.test.ts` — exit 1. 6 failed / 10 passed. Failures are assertion mismatches: received `client/**/*.{js,css,…}` where shell globs (`entry/**`, `assets/**`, `client/*.{ico,png,svg,webp}`) were expected. `precacheClient: true` cases already match today’s catch-all (pass for the old default).
+
+### Ticket 1 green proof
+
+Same command — exit 0, 16 passed (9 + 7). Theme-default suite: 176 passed.
+
+## Baseline
+
+Recorded on `ship/pwa-faster-update-prompt` at `84b431ade8731989d9996bafc92e98e2a5da6180` before implementation. Working tree contained only this spec file.
+
+- Criterion 1–4 command `pnpm --filter @sveltepress/theme-default exec vitest run __tests__/pwa-precache-pages.test.ts __tests__/pwa-options.test.ts` — GREEN on the **current** contract: 14 tests passed (8 + 6). Default glob still includes `client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}` and homepage HTML. No `precacheClient`, no `sveltepress-immutable` rule. This is the pre-change baseline; Ticket 1 will turn the default-glob assertions red, then green.
+- Criterion 5 (`precacheClient` in EN/ZH/BN PWA guides) — RED (exit 1). Missing: all three locale pages. Expected until Ticket 3.
+- Criterion 6 `pnpm test` — GREEN: scripts 40, cli 34, vite 185, theme-default 174, theme-blog 75, twoslash 6. Zero failures.
+- `pnpm run typecheck` does not exist in this repository. Global guardrail is `pnpm test`.

--- a/docs/specs/pwa-faster-update-prompt.md
+++ b/docs/specs/pwa-faster-update-prompt.md
@@ -130,7 +130,7 @@ The repository has no `pnpm run typecheck` script. Global guardrail for this cha
 ## Plan
 
 - [x] Ticket 1: Shell client precache glob — Delivers `precacheClient` on the glob helper and theme PWA options: default globs are entry + assets + root icons + existing HTML policy; `true` restores `client/**/*.{js,css,…}`; no nodes/chunks catch-all. Tests at pwa-precache-pages.test.ts and pwa-options.test.ts globPatterns. (Blocked by: none)
-- [ ] Ticket 2: Immutable CacheFirst runtime — Delivers generateSW `sveltepress-immutable` CacheFirst (400 / 30d) when shell-only, omitted when `precacheClient: true`; injectManifest `sw.js` registers the same route. Tests at pwa-options.test.ts runtimeCaching + sw.js source. (Blocked by: Ticket 1)
+- [x] Ticket 2: Immutable CacheFirst runtime — Delivers generateSW `sveltepress-immutable` CacheFirst (400 / 30d) when shell-only, omitted when `precacheClient: true`; injectManifest `sw.js` registers the same route. Tests at pwa-options.test.ts runtimeCaching + sw.js source. (Blocked by: Ticket 1)
 - [ ] Ticket 3: Release & Documentation Compliance — Delivers Changeset (minor on `@sveltepress/theme-default`) and PWA guide updates in EN / ZH / BN documenting `precacheClient` and the first-install hydration tradeoff. Root README has no PWA glob section to update. (Blocked by: Tickets 1–2)
 
 ## Ticket verification
@@ -142,6 +142,14 @@ The repository has no `pnpm run typecheck` script. Global guardrail for this cha
 ### Ticket 1 green proof
 
 Same command — exit 0, 16 passed (9 + 7). Theme-default suite: 176 passed.
+
+### Ticket 2 red proof
+
+Same command — exit 1. 2 failed / 15 passed. Default captured `workbox.runtimeCaching` had no `sveltepress-immutable`; `sw.js` did not contain `_app/immutable`.
+
+### Ticket 2 green proof
+
+Same command — exit 0, 17 passed (10 + 7).
 
 ## Baseline
 

--- a/docs/specs/pwa-faster-update-prompt.md
+++ b/docs/specs/pwa-faster-update-prompt.md
@@ -1,6 +1,6 @@
 # Spec: Faster PWA Refresh Prompt on Large Docs Sites
 
-Status: landing
+Status: shipped
 Branch: ship/pwa-faster-update-prompt
 Base-Commit: 84b431ade8731989d9996bafc92e98e2a5da6180
 Original-Branch: main

--- a/docs/specs/pwa-faster-update-prompt.md
+++ b/docs/specs/pwa-faster-update-prompt.md
@@ -131,7 +131,7 @@ The repository has no `pnpm run typecheck` script. Global guardrail for this cha
 
 - [x] Ticket 1: Shell client precache glob — Delivers `precacheClient` on the glob helper and theme PWA options: default globs are entry + assets + root icons + existing HTML policy; `true` restores `client/**/*.{js,css,…}`; no nodes/chunks catch-all. Tests at pwa-precache-pages.test.ts and pwa-options.test.ts globPatterns. (Blocked by: none)
 - [x] Ticket 2: Immutable CacheFirst runtime — Delivers generateSW `sveltepress-immutable` CacheFirst (400 / 30d) when shell-only, omitted when `precacheClient: true`; injectManifest `sw.js` registers the same route. Tests at pwa-options.test.ts runtimeCaching + sw.js source. (Blocked by: Ticket 1)
-- [ ] Ticket 3: Release & Documentation Compliance — Delivers Changeset (minor on `@sveltepress/theme-default`) and PWA guide updates in EN / ZH / BN documenting `precacheClient` and the first-install hydration tradeoff. Root README has no PWA glob section to update. (Blocked by: Tickets 1–2)
+- [x] Ticket 3: Release & Documentation Compliance — Delivers Changeset (minor on `@sveltepress/theme-default`) and PWA guide updates in EN / ZH / BN documenting `precacheClient` and the first-install hydration tradeoff. Root README has no PWA glob section to update. (Blocked by: Tickets 1–2)
 
 ## Ticket verification
 
@@ -150,6 +150,14 @@ Same command — exit 1. 2 failed / 15 passed. Default captured `workbox.runtime
 ### Ticket 2 green proof
 
 Same command — exit 0, 17 passed (10 + 7).
+
+### Ticket 3 red proof
+
+Criterion 5 at baseline: `precacheClient` missing from EN/ZH/BN PWA guides (exit 1).
+
+### Ticket 3 green proof
+
+Same python token check — exit 0 after EN/ZH/BN PWA guide updates. Minor changeset `.changeset/pwa-faster-update-prompt.md` added for `@sveltepress/theme-default`.
 
 ## Baseline
 

--- a/packages/docs-site/src/routes/bn/guide/default-theme/pwa/+page.md
+++ b/packages/docs-site/src/routes/bn/guide/default-theme/pwa/+page.md
@@ -36,11 +36,13 @@ export default config
 আপনার Vite project এ dev dependency হিসেবে `workbox-window` যুক্ত করতে হবে
 :::
 
-## HTML precache (versions & i18n)
+## Precache (versions & i18n)
 
-ডিফল্টভাবে Sveltepress শুধু **app shell** (JS / CSS / fonts) এবং **homepage** precache করে। বাকি ডকুমেন্টেশন পেজ ইউজার ভিজিট করলে runtime-এ cache হয় (`NetworkFirst`, সর্বোচ্চ 50টি এন্ট্রি)। ছবি এবং SvelteKit `__data.json`ও runtime cache হয়।
+ডিফল্টভাবে Sveltepress শুধু **app shell** এবং **homepage HTML** precache করে। Shell হলো SvelteKit-এর entry মডিউল, hashed CSS / fonts, এবং root icon — প্রতি-রুট `_app/immutable/nodes` বা shared chunk নয়। বাকি ডকুমেন্টেশন পেজ এবং সেই hashed মডিউল ইউজার ভিজিট করলে runtime-এ cache হয় (পেজ: `NetworkFirst`, সর্বোচ্চ 50টি এন্ট্রি; hashed client ফাইল: `CacheFirst`, সর্বোচ্চ 400টি / 30 দিন)। ছবি এবং SvelteKit `__data.json`ও runtime cache হয়।
 
-অনেক version এবং locale থাকলে এটি service worker install/update দ্রুত রাখে। সব prerendered HTML precache করলে Workbox প্রতিবার `versions × locales × pages` hash, compare এবং download করে।
+অনেক পেজ, version এবং locale থাকলে এটি service worker install/update দ্রুত রাখে, তাই deploy-এর পর refresh prompt তাড়াতাড়ি দেখা যায়। সব prerendered HTML বা সব client মডিউল precache করলে Workbox প্রতিবার `versions × locales × pages` hash, compare এবং download করে।
+
+প্রথম install-এ homepage hydration-এর জন্য নেটওয়ার্ক লাগতে পারে, যতক্ষণ না সেই hashed মডিউল runtime cache-এ যায়। একবার অনলাইনে ভিজিট করার পর ভিজিট করা পেজ (homepage সহ) runtime cache দিয়ে অফলাইনে খোলা যাবে।
 
 ### `pwa.precachePages`
 
@@ -75,6 +77,27 @@ defaultTheme({
 ```
 
 ভিজিট করা পেজ precache না থাকলেও runtime cache দিয়ে অফলাইনে খোলা যাবে।
+
+### `pwa.precacheClient`
+
+| Value | Precached client files |
+| --- | --- |
+| `false` (default) | শুধু app shell (entry + CSS / fonts + root icon) |
+| `true` | সব matching client file |
+
+আগের “সব client JS/CSS মডিউল precache করো” আচরণ ফিরিয়ে আনতে:
+
+```ts
+import { defaultTheme } from '@sveltepress/theme-default'
+
+defaultTheme({
+  pwa: {
+    precacheClient: true,
+  },
+})
+```
+
+`precachePages` এবং `precacheClient` আলাদা: HTML policy client glob বদলায় না, আবার উল্টোটাও না।
 
 ## কনফিগের উদাহরণ
 

--- a/packages/docs-site/src/routes/guide/default-theme/pwa/+page.md
+++ b/packages/docs-site/src/routes/guide/default-theme/pwa/+page.md
@@ -36,11 +36,13 @@ If you want to enable pwa.
 You will need to add `workbox-window` as a dev dependency to your Vite project.
 :::
 
-## HTML precache (versions & i18n)
+## Precache (versions & i18n)
 
-By default Sveltepress only precaches the **app shell** (JS / CSS / fonts) and the **homepage**. Other documentation pages are cached at runtime when the user visits them (`NetworkFirst`, capped at 50 entries). Images and SvelteKit `__data.json` responses are also runtime-cached.
+By default Sveltepress only precaches the **app shell** and the **homepage HTML**. The shell is SvelteKit’s entry modules, hashed CSS / fonts, and root icons — not per-route `_app/immutable/nodes` or shared chunks. Other documentation pages and those hashed modules are cached at runtime when the user visits them (pages: `NetworkFirst`, capped at 50 entries; hashed client files: `CacheFirst`, capped at 400 entries / 30 days). Images and SvelteKit `__data.json` responses are also runtime-cached.
 
-This keeps service worker install and update fast when the site has many versions and locales. Precaching every prerendered HTML file makes Workbox hash, compare and download `versions × locales × pages` on every update.
+This keeps service worker install and update fast when the site has many pages, versions, and locales, so the refresh prompt can appear soon after a deploy. Precaching every prerendered HTML file or every client module makes Workbox hash, compare and download `versions × locales × pages` on every update.
+
+On first install, homepage hydration may need the network until those hashed modules have been runtime-cached. After one online visit, visited pages (including home) stay available offline through the runtime cache.
 
 ### `pwa.precachePages`
 
@@ -79,6 +81,27 @@ A glob starting with `prerendered/` is always included. Otherwise `@vite-pwa/sve
 :::
 
 Visited pages still work offline through the runtime cache, even when they are not precached.
+
+### `pwa.precacheClient`
+
+| Value | Precached client files |
+| --- | --- |
+| `false` (default) | App shell only (entry + CSS / fonts + root icons) |
+| `true` | Every matching client file |
+
+Restore the previous “precache every client JS/CSS module” behavior:
+
+```ts
+import { defaultTheme } from '@sveltepress/theme-default'
+
+defaultTheme({
+  pwa: {
+    precacheClient: true,
+  },
+})
+```
+
+`precachePages` and `precacheClient` are independent: HTML policy does not change the client glob, and the other way around.
 
 ## Example config
 

--- a/packages/docs-site/src/routes/zh/guide/default-theme/pwa/+page.md
+++ b/packages/docs-site/src/routes/zh/guide/default-theme/pwa/+page.md
@@ -38,11 +38,13 @@ export default config
 
 :::
 
-## HTML 预缓存（多版本 / 多语言）
+## 预缓存（多版本 / 多语言）
 
-默认情况下，Sveltepress **只预缓存应用壳（JS / CSS / 字体）和首页**。其它文档页会在用户访问时按需写入运行时缓存（`NetworkFirst`，最多 50 条）。图片和 SvelteKit 的 `__data.json` 也会进入运行时缓存。
+默认情况下，Sveltepress **只预缓存应用壳和首页 HTML**。应用壳是 SvelteKit 的入口模块、哈希后的 CSS / 字体，以及站点根目录图标，**不包含**各路由的 `_app/immutable/nodes` 和共享 chunks。其它文档页和这些哈希模块会在用户访问时写入运行时缓存（页面：`NetworkFirst`，最多 50 条；哈希客户端文件：`CacheFirst`，最多 400 条 / 30 天）。图片和 SvelteKit 的 `__data.json` 也会进入运行时缓存。
 
-这样在版本多、语言多时，Service Worker 的安装和更新仍然很快。如果把所有预渲染 HTML 都放进 precache，每次更新 Workbox 都要哈希、对比、下载 `版本 × 语言 × 页面` 的笛卡尔积。
+这样在页面多、版本多、语言多时，Service Worker 的安装和更新仍然很快，站点更新后可以尽快弹出刷新提示。如果把所有预渲染 HTML 或全部客户端模块都放进 precache，每次更新 Workbox 都要哈希、对比、下载 `版本 × 语言 × 页面` 的笛卡尔积。
+
+首次安装时，首页的 hydration 可能仍需要网络，直到这些哈希模块被写入运行时缓存。在线访问过一次之后，访问过的页面（包括首页）仍可通过运行时缓存离线打开。
 
 ### `pwa.precachePages`
 
@@ -81,6 +83,27 @@ defaultTheme({
 :::
 
 即使页面没有被预缓存，用户访问过的页面仍可通过运行时缓存离线打开。
+
+### `pwa.precacheClient`
+
+| 取值 | 预缓存的客户端文件 |
+| --- | --- |
+| `false`（默认） | 仅应用壳（入口 + CSS / 字体 + 根目录图标） |
+| `true` | 全部匹配的客户端文件 |
+
+恢复「预缓存每一个客户端 JS/CSS 模块」的旧行为：
+
+```ts
+import { defaultTheme } from '@sveltepress/theme-default'
+
+defaultTheme({
+  pwa: {
+    precacheClient: true,
+  },
+})
+```
+
+`precachePages` 和 `precacheClient` 彼此独立：HTML 策略不会改变客户端 glob，反之亦然。
 
 ## 配置示例
 

--- a/packages/theme-default/__tests__/manifestless-bundle.test.ts
+++ b/packages/theme-default/__tests__/manifestless-bundle.test.ts
@@ -17,7 +17,7 @@ const reviewedManifestlessHashes = {
   'SidebarGroup.svelte': '5c30e45e371b667aac36e65be5c950e4368bb79e7e69d4392fab35373652cf1f',
   'Toc.svelte': 'b260bce61dc3ce8af1c7fbb7d5f6e08f24c1df15dc3f91f6ef77f45253c93775',
   'layout.ts': '430ecf785cf02871acc04e3de954e37b92a0c2c4586329bef610b4a794df2eb9',
-  'pwa/sw.js': 'b0de55ae0e12539aaddb8d48175d840c80f95f26dcfccf023a4f0ba86bd1d033',
+  'pwa/sw.js': '3469249fff0fd12af1b33c65e9f38fb8b27bdbcf2db228a7410ea7b43e049e31',
 }
 
 describe('manifestless default theme', () => {

--- a/packages/theme-default/__tests__/pwa-options.test.ts
+++ b/packages/theme-default/__tests__/pwa-options.test.ts
@@ -68,6 +68,18 @@ describe('theme-default PWA configuration', () => {
     expect(navCaching.options.cacheName).toBe('sveltepress-pages')
     expect(navCaching.options.expiration.maxEntries).toBe(50)
 
+    const immutableCaching = pwa.workbox.runtimeCaching.find(
+      (rc: any) => rc.options?.cacheName === 'sveltepress-immutable',
+    )
+    expect(immutableCaching).toBeDefined()
+    expect(immutableCaching.handler).toBe('CacheFirst')
+    expect(immutableCaching.options.expiration.maxEntries).toBe(400)
+    expect(immutableCaching.options.expiration.maxAgeSeconds).toBe(30 * 24 * 60 * 60)
+    const immutableUrl = { pathname: '/_app/immutable/nodes/1.abc.js' }
+    const otherUrl = { pathname: '/guide/' }
+    expect(immutableCaching.urlPattern({ url: immutableUrl })).toBe(true)
+    expect(immutableCaching.urlPattern({ url: otherUrl })).toBe(false)
+
     // dontCacheBustURLsMatching should be configured
     expect(pwa.injectManifest.dontCacheBustURLsMatching).toBeDefined()
     expect(pwa.workbox.dontCacheBustURLsMatching).toBeDefined()
@@ -232,6 +244,9 @@ describe('theme-default PWA configuration', () => {
       'client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}',
       'prerendered/pages/index.html',
     ])
+    expect(pwa.workbox.runtimeCaching.some(
+      (rc: any) => rc.options?.cacheName === 'sveltepress-immutable',
+    )).toBe(false)
   })
 
   it('restricts the injectManifest navigation fallback to the root route in production', () => {
@@ -242,6 +257,10 @@ describe('theme-default PWA configuration', () => {
     expect(sw).toContain('allowlist: [/^\\/$/]')
     expect(sw).toContain('workbox-expiration')
     expect(sw).toContain('__data.json')
+    expect(sw).toContain('_app/immutable')
+    expect(sw).toContain('CacheFirst')
+    expect(sw).toContain('sveltepress-immutable')
+    expect(sw).toContain('maxEntries: 400')
     expect(sw).not.toContain('import.meta.env.DEV')
   })
 })

--- a/packages/theme-default/__tests__/pwa-options.test.ts
+++ b/packages/theme-default/__tests__/pwa-options.test.ts
@@ -43,15 +43,21 @@ describe('theme-default PWA configuration', () => {
     expect(capturedPwaOptions).toHaveLength(1)
     const pwa = capturedPwaOptions[0]
 
-    // Precache patterns should only include static assets and root page, NOT all prerendered html
-    expect(pwa.injectManifest.globPatterns).toEqual([
-      'client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}',
+    // Precache patterns should only include the app shell and homepage, NOT
+    // every hashed node/chunk or all prerendered html
+    const shellGlobs = [
+      'client/_app/immutable/entry/**/*.{js,css}',
+      'client/_app/immutable/assets/**/*.{css,otf,woff,woff2}',
+      'client/*.{ico,png,svg,webp}',
       'prerendered/pages/index.html',
-    ])
-    expect(pwa.workbox.globPatterns).toEqual([
+    ]
+    expect(pwa.injectManifest.globPatterns).toEqual(shellGlobs)
+    expect(pwa.workbox.globPatterns).toEqual(shellGlobs)
+    expect(pwa.injectManifest.globPatterns).not.toContain(
       'client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}',
-      'prerendered/pages/index.html',
-    ])
+    )
+    expect(pwa.injectManifest.globPatterns.some((g: string) => g.includes('nodes/'))).toBe(false)
+    expect(pwa.injectManifest.globPatterns.some((g: string) => g.includes('chunks/'))).toBe(false)
 
     // Runtime caching should be registered for document navigation
     const navCaching = pwa.workbox.runtimeCaching.find(
@@ -110,11 +116,15 @@ describe('theme-default PWA configuration', () => {
     const pwa = capturedPwaOptions[0]
 
     expect(pwa.injectManifest.globPatterns).toEqual([
-      'client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}',
+      'client/_app/immutable/entry/**/*.{js,css}',
+      'client/_app/immutable/assets/**/*.{css,otf,woff,woff2}',
+      'client/*.{ico,png,svg,webp}',
       'prerendered/**/*.html',
     ])
     expect(pwa.workbox.globPatterns).toEqual([
-      'client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}',
+      'client/_app/immutable/entry/**/*.{js,css}',
+      'client/_app/immutable/assets/**/*.{css,otf,woff,woff2}',
+      'client/*.{ico,png,svg,webp}',
       'prerendered/**/*.html',
     ])
     // When precaching all pages, docPagesRuntimeCaching is not added
@@ -142,7 +152,9 @@ describe('theme-default PWA configuration', () => {
     const pwa = capturedPwaOptions[0]
 
     expect(pwa.injectManifest.globPatterns).toEqual([
-      'client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}',
+      'client/_app/immutable/entry/**/*.{js,css}',
+      'client/_app/immutable/assets/**/*.{css,otf,woff,woff2}',
+      'client/*.{ico,png,svg,webp}',
       'prerendered/pages/index.html',
       'prerendered/pages/zh.html',
       'prerendered/pages/zh/**',
@@ -194,6 +206,32 @@ describe('theme-default PWA configuration', () => {
       (rc: any) => rc.options?.cacheName === 'sveltepress-pages',
     )
     expect(customIndex).toBeLessThan(docIndex)
+  })
+
+  it('restores the catch-all client glob when precacheClient is true', async () => {
+    capturedPwaOptions.length = 0
+    const { defaultTheme } = await import('../src/index')
+
+    const theme = defaultTheme({
+      pwa: {
+        scope: '/',
+        precacheClient: true,
+      },
+    })
+
+    const dummyCore = { name: 'core-plugin' }
+    await (theme.vitePlugins as any)(dummyCore)
+
+    expect(capturedPwaOptions).toHaveLength(1)
+    const pwa = capturedPwaOptions[0]
+    expect(pwa.injectManifest.globPatterns).toEqual([
+      'client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}',
+      'prerendered/pages/index.html',
+    ])
+    expect(pwa.workbox.globPatterns).toEqual([
+      'client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}',
+      'prerendered/pages/index.html',
+    ])
   })
 
   it('restricts the injectManifest navigation fallback to the root route in production', () => {

--- a/packages/theme-default/__tests__/pwa-precache-pages.test.ts
+++ b/packages/theme-default/__tests__/pwa-precache-pages.test.ts
@@ -2,11 +2,26 @@ import { describe, expect, it } from 'vitest'
 import {
   prefixToPrerenderedGlobs,
   PWA_ALL_HTML_GLOB,
+  PWA_CLIENT_ASSETS_GLOB,
+  PWA_CLIENT_ENTRY_GLOB,
   PWA_CLIENT_GLOB,
+  PWA_CLIENT_ROOT_ICONS_GLOB,
   PWA_HOME_GLOB,
   resolvePrecacheGlobPatterns,
   shouldRuntimeCachePages,
 } from '../src/pwa/precache-pages'
+
+const SHELL_CLIENT_GLOBS = [
+  PWA_CLIENT_ENTRY_GLOB,
+  PWA_CLIENT_ASSETS_GLOB,
+  PWA_CLIENT_ROOT_ICONS_GLOB,
+]
+
+function expectNoCatchAllOrRouteModules(patterns: string[]) {
+  expect(patterns).not.toContain(PWA_CLIENT_GLOB)
+  expect(patterns.some(g => g.includes('nodes/'))).toBe(false)
+  expect(patterns.some(g => g.includes('chunks/'))).toBe(false)
+}
 
 describe('prefixToPrerenderedGlobs', () => {
   it('maps homepage prefixes to the index.html glob', () => {
@@ -27,9 +42,11 @@ describe('prefixToPrerenderedGlobs', () => {
 })
 
 describe('resolvePrecacheGlobPatterns', () => {
-  it('defaults to homepage-only HTML so versioned/i18n sites stay small', () => {
-    expect(resolvePrecacheGlobPatterns()).toEqual([PWA_CLIENT_GLOB, PWA_HOME_GLOB])
-    expect(resolvePrecacheGlobPatterns(false)).toEqual([PWA_CLIENT_GLOB, PWA_HOME_GLOB])
+  it('defaults to app-shell client files and homepage-only HTML', () => {
+    const expected = [...SHELL_CLIENT_GLOBS, PWA_HOME_GLOB]
+    expect(resolvePrecacheGlobPatterns()).toEqual(expected)
+    expect(resolvePrecacheGlobPatterns(false)).toEqual(expected)
+    expectNoCatchAllOrRouteModules(expected)
   })
 
   it('includes a prerendered/ glob so sveltekit-pwa does not add the catch-all', () => {
@@ -38,16 +55,17 @@ describe('resolvePrecacheGlobPatterns', () => {
     }
   })
 
-  it('can restore the old full-precache behavior', () => {
+  it('can restore the old full HTML precache without restoring every client file', () => {
     expect(resolvePrecacheGlobPatterns(true)).toEqual([
-      PWA_CLIENT_GLOB,
+      ...SHELL_CLIENT_GLOBS,
       PWA_ALL_HTML_GLOB,
     ])
+    expectNoCatchAllOrRouteModules(resolvePrecacheGlobPatterns(true))
   })
 
   it('precaches homepage plus selected version/locale prefixes', () => {
     expect(resolvePrecacheGlobPatterns(['/zh/', '/v/2026-08-27/'])).toEqual([
-      PWA_CLIENT_GLOB,
+      ...SHELL_CLIENT_GLOBS,
       PWA_HOME_GLOB,
       'prerendered/pages/zh.html',
       'prerendered/pages/zh/**',
@@ -59,6 +77,23 @@ describe('resolvePrecacheGlobPatterns', () => {
   it('deduplicates homepage when it is also listed as a prefix', () => {
     const patterns = resolvePrecacheGlobPatterns(['/', '/zh/'])
     expect(patterns.filter(g => g === PWA_HOME_GLOB)).toHaveLength(1)
+  })
+
+  it('restores the catch-all client glob when precacheClient is true', () => {
+    expect(resolvePrecacheGlobPatterns(false, true)).toEqual([
+      PWA_CLIENT_GLOB,
+      PWA_HOME_GLOB,
+    ])
+    expect(resolvePrecacheGlobPatterns(true, true)).toEqual([
+      PWA_CLIENT_GLOB,
+      PWA_ALL_HTML_GLOB,
+    ])
+    expect(resolvePrecacheGlobPatterns(['/zh/'], true)).toEqual([
+      PWA_CLIENT_GLOB,
+      PWA_HOME_GLOB,
+      'prerendered/pages/zh.html',
+      'prerendered/pages/zh/**',
+    ])
   })
 })
 

--- a/packages/theme-default/__tests__/pwa-precache-pages.test.ts
+++ b/packages/theme-default/__tests__/pwa-precache-pages.test.ts
@@ -8,6 +8,7 @@ import {
   PWA_CLIENT_ROOT_ICONS_GLOB,
   PWA_HOME_GLOB,
   resolvePrecacheGlobPatterns,
+  shouldRuntimeCacheClient,
   shouldRuntimeCachePages,
 } from '../src/pwa/precache-pages'
 
@@ -103,5 +104,13 @@ describe('shouldRuntimeCachePages', () => {
     expect(shouldRuntimeCachePages(false)).toBe(true)
     expect(shouldRuntimeCachePages(['/zh/'])).toBe(true)
     expect(shouldRuntimeCachePages(true)).toBe(false)
+  })
+})
+
+describe('shouldRuntimeCacheClient', () => {
+  it('runtime-caches hashed modules unless every client file is already precached', () => {
+    expect(shouldRuntimeCacheClient()).toBe(true)
+    expect(shouldRuntimeCacheClient(false)).toBe(true)
+    expect(shouldRuntimeCacheClient(true)).toBe(false)
   })
 })

--- a/packages/theme-default/src/components/pwa/sw.js
+++ b/packages/theme-default/src/components/pwa/sw.js
@@ -92,4 +92,17 @@ registerRoute(
   }),
 )
 
+registerRoute(
+  ({ url }) => url.pathname.includes('/_app/immutable/'),
+  new CacheFirst({
+    cacheName: 'sveltepress-immutable',
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 400,
+        maxAgeSeconds: 30 * 24 * 60 * 60,
+      }),
+    ],
+  }),
+)
+
 registerRoute(route)

--- a/packages/theme-default/src/index.ts
+++ b/packages/theme-default/src/index.ts
@@ -46,12 +46,14 @@ const defaultTheme: ThemeDefault = (options) => {
       const pwaOptions = options.pwa as SvelteKitPWAOptions & {
         darkManifest?: string
         precachePages?: boolean | string[]
+        precacheClient?: boolean
       } & Record<string, any>
       const precachePages = pwaOptions.precachePages ?? false
+      const precacheClient = pwaOptions.precacheClient ?? false
       const historicalGlob = versionManifest
         ? `prerendered/pages/**${versionManifest.basePath}/**/*.html`
         : null
-      const defaultGlobPatterns = resolvePrecacheGlobPatterns(precachePages)
+      const defaultGlobPatterns = resolvePrecacheGlobPatterns(precachePages, precacheClient)
       const versionRuntimeCaching = versionManifest
         ? [{
             urlPattern: new RegExp(`^${versionManifest.basePath}/`),

--- a/packages/theme-default/src/index.ts
+++ b/packages/theme-default/src/index.ts
@@ -14,7 +14,7 @@ import installPkg from './markdown/install-pkg.js'
 import links from './markdown/links.js'
 import liveCode from './markdown/live-code.js'
 import versionChanges from './markdown/version-changes.js'
-import { resolvePrecacheGlobPatterns, shouldRuntimeCachePages } from './pwa/precache-pages.js'
+import { resolvePrecacheGlobPatterns, shouldRuntimeCacheClient, shouldRuntimeCachePages } from './pwa/precache-pages.js'
 import { createVersionManifestReader } from './version-manifest.js'
 import createPreCorePlugins from './vite-plugins/create-pre-core-plugins.js'
 
@@ -78,6 +78,22 @@ const defaultTheme: ThemeDefault = (options) => {
             },
           }]
         : []
+      const immutableRuntimeCaching = shouldRuntimeCacheClient(precacheClient)
+        ? [{
+            urlPattern: ({ url }: any) => url.pathname.includes('/_app/immutable/'),
+            handler: 'CacheFirst' as const,
+            options: {
+              cacheName: 'sveltepress-immutable',
+              expiration: {
+                maxEntries: 400,
+                maxAgeSeconds: 30 * 24 * 60 * 60,
+              },
+              cacheableResponse: {
+                statuses: [200],
+              },
+            },
+          }]
+        : []
       const assetRuntimeCaching = [
         {
           urlPattern: ({ url }: any) => url.pathname.includes('/__data.json'),
@@ -135,6 +151,7 @@ const defaultTheme: ThemeDefault = (options) => {
             ...versionRuntimeCaching,
             ...(pwaOptions.workbox?.runtimeCaching ?? []),
             ...docPagesRuntimeCaching,
+            ...immutableRuntimeCaching,
             ...assetRuntimeCaching,
           ],
         },

--- a/packages/theme-default/src/pwa/precache-pages.ts
+++ b/packages/theme-default/src/pwa/precache-pages.ts
@@ -11,9 +11,22 @@
  */
 export type PrecachePages = boolean | string[]
 
+/** Catch-all used when `precacheClient: true`. */
 export const PWA_CLIENT_GLOB = 'client/**/*.{js,css,ico,png,svg,webp,otf,woff,woff2}'
+/** SvelteKit start/app entry modules (hashed filenames live under this directory). */
+export const PWA_CLIENT_ENTRY_GLOB = 'client/_app/immutable/entry/**/*.{js,css}'
+/** Hashed CSS and fonts referenced by the shell. */
+export const PWA_CLIENT_ASSETS_GLOB = 'client/_app/immutable/assets/**/*.{css,otf,woff,woff2}'
+/** Root-level PWA / favicon images (not nested under `_app`). */
+export const PWA_CLIENT_ROOT_ICONS_GLOB = 'client/*.{ico,png,svg,webp}'
 export const PWA_HOME_GLOB = 'prerendered/pages/index.html'
 export const PWA_ALL_HTML_GLOB = 'prerendered/**/*.html'
+
+export const PWA_SHELL_CLIENT_GLOBS = [
+  PWA_CLIENT_ENTRY_GLOB,
+  PWA_CLIENT_ASSETS_GLOB,
+  PWA_CLIENT_ROOT_ICONS_GLOB,
+] as const
 
 /**
  * Map a site URL prefix to Workbox globs under `.svelte-kit/output`.
@@ -29,26 +42,42 @@ export function prefixToPrerenderedGlobs(prefix: string): string[] {
   ]
 }
 
+function clientGlobs(precacheClient = false): string[] {
+  return precacheClient ? [PWA_CLIENT_GLOB] : [...PWA_SHELL_CLIENT_GLOBS]
+}
+
 /**
  * Build `injectManifest` / `workbox` `globPatterns`.
  *
  * A glob starting with `prerendered/` MUST be present, otherwise
  * `@vite-pwa/sveltekit` appends a catch-all for every prerendered HTML/JSON
  * file and every version/locale page is hashed into the precache again.
+ *
+ * Default `precacheClient` is shell-only (entry + CSS/fonts + root icons)
+ * so Workbox install stays cheap. `true` restores the catch-all client glob.
  */
-export function resolvePrecacheGlobPatterns(precachePages: PrecachePages = false): string[] {
+export function resolvePrecacheGlobPatterns(
+  precachePages: PrecachePages = false,
+  precacheClient = false,
+): string[] {
+  const client = clientGlobs(precacheClient)
   if (precachePages === true)
-    return [PWA_CLIENT_GLOB, PWA_ALL_HTML_GLOB]
+    return [...client, PWA_ALL_HTML_GLOB]
 
   if (Array.isArray(precachePages)) {
     const extra = precachePages.flatMap(prefixToPrerenderedGlobs)
-    return [...new Set([PWA_CLIENT_GLOB, PWA_HOME_GLOB, ...extra])]
+    return [...new Set([...client, PWA_HOME_GLOB, ...extra])]
   }
 
-  return [PWA_CLIENT_GLOB, PWA_HOME_GLOB]
+  return [...client, PWA_HOME_GLOB]
 }
 
 /** Runtime-cache visited pages unless every HTML file is already precached. */
 export function shouldRuntimeCachePages(precachePages: PrecachePages = false): boolean {
   return precachePages !== true
+}
+
+/** Runtime-cache hashed modules unless every client file is already precached. */
+export function shouldRuntimeCacheClient(precacheClient = false): boolean {
+  return precacheClient !== true
 }

--- a/packages/theme-default/types.d.ts
+++ b/packages/theme-default/types.d.ts
@@ -60,6 +60,18 @@ declare module 'virtual:sveltepress/theme-default' {
        * - `string[]`: URL prefixes, e.g. `['/zh/', '/v/2026-08-27/']`
        */
       precachePages?: boolean | string[]
+      /**
+       * Which client files to put in the Workbox precache.
+       *
+       * Default `false` only precaches the app shell (SvelteKit entry,
+       * hashed CSS/fonts, and root icons) so service-worker install/update
+       * stays fast on sites with many pages. Per-route nodes and chunks
+       * are fetched on demand.
+       *
+       * - `false`: app shell only
+       * - `true`: every matching client file (the previous catch-all glob)
+       */
+      precacheClient?: boolean
     }
     docsearch?: Omit<DocSearchProps, 'container' | 'theme'>
     search?: Component | string | boolean


### PR DESCRIPTION
## Summary

On large docs sites the PWA refresh toast waited until Workbox finished installing a huge client precache. HTML was already homepage-only, but the default glob still matched every hashed client file (on the official docs site, on the order of 800 files: hundreds of per-route SvelteKit nodes plus shared chunks).

This change makes the Default Theme default client precache an **app shell**:

- SvelteKit entry modules
- hashed CSS / fonts
- root icons
- homepage HTML (existing `precachePages` policy)

Per-route nodes and chunks are fetched on demand and stored with a capped CacheFirst runtime cache (`sveltepress-immutable`, 400 entries / 30 days). The click-to-reload toast is unchanged; it just reaches `waiting` sooner.

`pwa.precacheClient: true` restores the previous catch-all client glob. `pwa.precachePages` still controls HTML only.

## User-facing

- **Default:** smaller service-worker install/update on `@sveltepress/theme-default` PWA sites (injectManifest and generateSW).
- **Opt-in:** `precacheClient: true` for the old “precache every client file” behavior.
- **Tradeoff:** first-install homepage hydration may need the network until hashed modules have been runtime-cached. Visited pages stay offline via runtime cache.
- Docs updated in EN / ZH / BN. Minor changeset for `@sveltepress/theme-default`.

Spec: `docs/specs/pwa-faster-update-prompt.md`

## Test plan

- [x] `pnpm --filter @sveltepress/theme-default exec vitest run __tests__/pwa-precache-pages.test.ts __tests__/pwa-options.test.ts` — 17 passed; default globs are shell + homepage HTML; `precacheClient: true` restores catch-all; CacheFirst `sveltepress-immutable` 400/30d when shell-only; `sw.js` registers the same route
- [x] EN / ZH / BN PWA guides contain `precacheClient`
- [x] `pnpm test` — zero failures (theme-default 177 vs previous 174, +3 new PWA tests)

## Notes

Unrelated local sidebar / `reference/versions` files in the working tree are **not** in this PR.